### PR TITLE
Overquanitization, or: What's wrong with our feature?

### DIFF
--- a/notebook.ipynb
+++ b/notebook.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 54,
    "id": "1fbbe1dd",
    "metadata": {},
    "outputs": [],
@@ -16,17 +16,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 55,
    "id": "e8320198",
    "metadata": {},
    "outputs": [],
    "source": [
+    "# deterministic, it seems\n",
     "files = load_files('./avatars', load_content=False)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 56,
    "id": "aa8b6469",
    "metadata": {},
    "outputs": [
@@ -36,7 +37,7 @@
        "dict_keys(['filenames', 'target_names', 'target', 'DESCR'])"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 56,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -47,9 +48,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 57,
    "id": "6e525e6d",
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
      "data": {
@@ -66,7 +69,7 @@
        "       0, 1])"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 57,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -78,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 58,
    "id": "0236c228",
    "metadata": {},
    "outputs": [
@@ -88,7 +91,7 @@
        "['custom', 'default']"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 58,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -100,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 59,
    "id": "c68cec69",
    "metadata": {},
    "outputs": [
@@ -110,14 +113,23 @@
        "[array([ 0, 96, 32])]"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 59,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "def file_to_color_histogram(path):\n",
+    "def file_to_color_histogram(path, bit_depth=8):\n",
+    "    pix = load_pixels(path)\n",
+    "    color_index_array = rgb_to_index(pix, bit_depth=bit_depth)\n",
     "    \n",
+    "    # count number of occurrences of each value in array of non-negative ints\n",
+    "    color_index_counts = np.bincount(color_index_array, minlength=bit_depth**3)\n",
+    "\n",
+    "    # feature vector OMG!\n",
+    "    return color_index_counts\n",
+    "\n",
+    "def load_pixels(path):\n",
     "    # open the file with pillow, resize it, normalize\n",
     "    image = Image.open(path)\n",
     "    image = image.resize((16, 16))\n",
@@ -125,25 +137,24 @@
     "\n",
     "    # use numpy to extra an array of pixel data from the image\n",
     "    data = image.getdata()\n",
-    "    pix = np.array(data)\n",
+    "    return np.array(data)\n",
     "\n",
-    "    # divide each pixel by 32 and round\n",
-    "    pix = pix//32 \n",
+    "# take an rgb array and run an integer representing the \"color index\"\n",
+    "def rgb_to_index(pix, bit_depth=8):\n",
+    "    quanitization_factor = 256//bit_depth\n",
+    "    # divide each pixel by 32 and rounds\n",
+    "    pix = pix//quanitization_factor \n",
     "\n",
     "    # convert octal numbers to decimal numbers\n",
     "    # red is multiplied by 64\n",
     "    # green is multiplied by 8\n",
     "    # blue is multiplied by 1\n",
-    "    multiplier = np.array([8**2, 8**1, 8**0])\n",
+    "    multiplier = np.array([bit_depth**2, bit_depth**1, bit_depth**0])\n",
     "\n",
-    "    transformed_pixel_values = np.sum(pix*multiplier, axis=1)\n",
+    "    return np.sum(pix*multiplier, axis=1)\n",
     "\n",
-    "    # count number of occurrences of each value in array of non-negative ints\n",
-    "    feature_vector_omg = np.bincount(transformed_pixel_values, minlength=512)\n",
     "\n",
-    "    return feature_vector_omg\n",
-    "\n",
-    "# make a function that takes a histogram index and spits out an rgb value\n",
+    "# take a histogram index and spits out an rgb value\n",
     "def index_to_rgb(index):\n",
     "    r = index//64%8\n",
     "    g = index//8%8\n",
@@ -155,7 +166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 60,
    "id": "108e7260",
    "metadata": {},
    "outputs": [],
@@ -164,53 +175,23 @@
     "# and each element in the array is the count of the number of pixels of that color\n",
     "histograms = []\n",
     "for file in files[\"filenames\"]:\n",
-    "    histogram = file_to_color_histogram(file)\n",
+    "    histogram = file_to_color_histogram(file, bit_depth=8)\n",
     "    histograms.append(histogram)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 61,
    "id": "aeb6957b",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([14,  1,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,\n",
-       "        0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,\n",
-       "        0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,\n",
-       "        0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  2,  0,  0,  0,\n",
-       "        0,  0,  0,  0,  1, 18,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,\n",
-       "        0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,\n",
-       "        0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,\n",
-       "        0,  0,  0,  0,  0,  0,  0,  0,  0,  4,  0,  0,  0,  0,  0,  0,  0,\n",
-       "        0, 11,  0,  0,  0,  0,  0,  0,  0,  3, 16,  2,  0,  0,  0,  0,  0,\n",
-       "        0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,\n",
-       "        0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,\n",
-       "        0,  0,  0,  0,  0,  4,  0,  0,  0,  0,  0,  0,  0,  0, 10,  0,  0,\n",
-       "        0,  0,  0,  0,  0,  6, 16,  1,  0,  0,  0,  0,  0,  0,  0,  9,  0,\n",
-       "        0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,\n",
-       "        0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,\n",
-       "        0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,\n",
-       "        0,  0,  1,  0,  0,  0,  0,  0,  0,  0,  3,  6,  0,  0,  0,  0,  0,\n",
-       "        0,  0,  0,  8,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,\n",
-       "        0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,\n",
-       "        0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,\n",
-       "        0,  0,  0,  0,  0,  0,  0,  2,  0,  0,  0,  0,  0,  0,  0,  1,  3,\n",
-       "        1,  0,  0,  0,  0,  0,  0,  1, 14,  2,  0,  0,  0,  0,  0,  0,  1,\n",
-       "        3,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,\n",
-       "        0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,\n",
-       "        0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  2,  1,  0,  0,  0,\n",
-       "        0,  0,  0,  1,  4,  1,  0,  0,  0,  0,  0,  0,  0, 66, 15,  0,  0,\n",
-       "        0,  0,  0,  0,  0,  2,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,\n",
-       "        0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,\n",
-       "        0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,\n",
-       "        0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,\n",
-       "        0,  0])"
+       "512"
       ]
      },
-     "execution_count": 42,
+     "execution_count": 61,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -218,12 +199,12 @@
    "source": [
     "\n",
     "histograms[0]\n",
-    "#len(histograms[0])"
+    "len(histograms[0])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 62,
    "id": "19b5acc0",
    "metadata": {},
    "outputs": [
@@ -233,7 +214,7 @@
        "(512,)"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 62,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -244,7 +225,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 63,
    "id": "16a5ce4f",
    "metadata": {},
    "outputs": [
@@ -254,7 +235,7 @@
        "[100, 100, 100, 100]"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 63,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -282,7 +263,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 64,
    "id": "c1334e1e",
    "metadata": {},
    "outputs": [
@@ -291,20 +272,20 @@
       "text/plain": [
        "[Text(133.92000000000002, 190.26, 'X[511] <= 67.5\\ngini = 0.48\\nsamples = 100\\nvalue = [40, 60]'),\n",
        " Text(66.96000000000001, 135.9, 'gini = 0.0\\nsamples = 33\\nvalue = [33, 0]'),\n",
-       " Text(200.88000000000002, 135.9, 'X[438] <= 2.0\\ngini = 0.187\\nsamples = 67\\nvalue = [7, 60]'),\n",
-       " Text(133.92000000000002, 81.53999999999999, 'X[483] <= 0.5\\ngini = 0.032\\nsamples = 61\\nvalue = [1, 60]'),\n",
+       " Text(200.88000000000002, 135.9, 'X[365] <= 0.5\\ngini = 0.187\\nsamples = 67\\nvalue = [7, 60]'),\n",
+       " Text(133.92000000000002, 81.53999999999999, 'X[511] <= 200.5\\ngini = 0.032\\nsamples = 61\\nvalue = [1, 60]'),\n",
        " Text(66.96000000000001, 27.180000000000007, 'gini = 0.0\\nsamples = 60\\nvalue = [0, 60]'),\n",
        " Text(200.88000000000002, 27.180000000000007, 'gini = 0.0\\nsamples = 1\\nvalue = [1, 0]'),\n",
        " Text(267.84000000000003, 81.53999999999999, 'gini = 0.0\\nsamples = 6\\nvalue = [6, 0]')]"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 64,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAV0AAADnCAYAAAC9roUQAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8/fFQqAAAACXBIWXMAAAsTAAALEwEAmpwYAABJkklEQVR4nO3de1zN2f4/8NfOpRqSUijdqGQntaMdRTMujUJTzbhUrukxiKHz+8405JgojMvImdFwMGbKPR6oY8YtUWYiESmZFENNVCiRbqR6//7o9Dm2vUuXrX1pPR+Pz+Nhfz7rsz7rU2svq3XlEREYhmGY9qEi6wQwDMN0JKzQZRiGaUes0GUYhmlHrNBlGIZpR6zQZRiGaUes0GUYhmlHnWWdgI5MXV390cuXL/vIOh0dhZqa2uOqqqq+sk4H07Hx2Dhd2eHxeMR+/u2Hx+OBiHiyTgfTsbHmBYZhmHbECl2GYZh2xApdhmGYdsQKXYZhmHbECl05VFBQAENDQxQUFAAAqqurYWVlhYsXLyI3NxdqamoQCASoqqoCAJiYmMDKygoCgQACgQBPnz4FAJw9exa2trbo3LkzDh06JPIMHx8f9O7dG4MGDRI5f+DAAZiZmcHV1bUd3rTejh07MGjQIAwePBizZ88GACQmJnLvIxAI0L17d2zZskXs3gsXLqBHjx5cuC+++KLd0s0wrUJE7JDRUf/jlyw8PJwmT55MRESrV6+mzz//nIiIcnJyyMLCQiSssbExFRYWisXx119/0c2bN2nWrFkUFRUlci0hIYGuX78uFlfDNRcXl0bT9ra6ujp69uxZs8O/6ffff6eRI0dSeXk5ERE9evRILMzLly9JW1ub8vLy2pTW//68Zf57Z0fHPlhNV0598cUXyMvLw/fff4+ff/4Z3333XYvjMDU1xZAhQ6CiIv5rHj16NLS1tduUxtzcXISGhsLCwgKnT59uVRzbtm3D8uXL0a1bNwBAnz7iw5ZPnToFa2trGBoatim9DCMPWKErp1RUVLBlyxZ8+eWXWLNmDbS0tBoNy+PxMHHiRNja2mLDhg3vNV2VlZXYt28fxo0bhylTpkBTUxOXLl2Cj48PAODo0aMizQJvHpJkZ2fj6tWrGDFiBBwcHBAXFycW5sCBA5gxY0ajabp69SoEAgHGjh2LpKQkqbwnw7wvbEaaHDt9+jT09PSQkZHRZLjExEQYGBjg+fPn+PTTT2FgYICZM2e+lzT17dsXgwYNwq5du2BjYyN2fcqUKZgyZUqz46upqUF+fj6SkpJw//59jB49Gn/++Sc0NTUBAC9evMC5c+fwyy+/SLx/6NCh+Pvvv6GhoYHLly9j6tSpyMzMRI8ePVr3ggzznrGarpzKysrC/v37cf36dURHRzdZ8BoYGAAAevbsiRkzZiA5Ofm9pSs6Ohrm5uaYOnUqgoKCkJmZKXK9pTVdQ0NDTJ48GSoqKjAzM4OpqSnu3LnDXT927BicnZ25QvhtPXr0gIaGBgDAwcEBJiYmIvczjLxhha6c8vf3x6ZNm6Cnp4fNmzfD398fROJThisqKvDixQsA9aMcfvvtNwwZMuS9pcvZ2RkHDhzAtWvXMGDAAMybNw9CoRCXLl0CUF/TTUtLk3hI8tlnn+H8+fMAgMePH+PevXsYMGAAd/1dTQuPHj3ifi537tzBvXv3YGpqKqW3ZZj3QNY9eR35QCOjFyIjI8nNzU3knJubG/30009ioxfu3btHNjY2NGTIELK0tKQvv/ySampqiKi+Z79fv370wQcfkLa2NvXr14+775NPPqG+fftS586dqV+/frR582buWktHL2RnZ1N6enqzw7+purqafH19ydLSkoYMGUJHjhzhrhUUFFCvXr3o1atXIvds376dtm/fTkREP/74I1laWpKNjQ0NGzaMTpw40eizwEYvsEMODrbgjQy1ZsGb3NxcuLq6Iisr6z2lqn7s64YNG3DmzJn39gxZYAveMPKANS8omE6dOqG8vFxkcoQ0HThwAIsWLWrzcDKGYSRjNV0ZYks7ti9W02XkAavpKrkdO3YgMjKyyTAFBQX49NNPpfK8AwcOwNzcHGZmZti8eXOTYa9cuYJOnTqJTFGOioqCtbU1BAIBPvzwQ/z1119SSRfDyAtW05UhZavpPn/+HLa2trh69Sq6d++OYcOGISYmBhYWFmJha2pq4OzsjA8++ACzZ8+Gt7c3qquroa+vj9u3b0NXVxdbt27FlStXsG/fPqmkj9V0GXnAarpKYvfu3TA3N4dQKIS/vz98fX0BACEhIdwstdGjR2PZsmUYMWIEBgwYgJMnTwKo75x7e+Gb1jhz5gzGjh0LXV1dqKurw8vLCzExMRLDbtq0iVt0p0FD725ZWRkAoLS0FHp6em1OF8PIEzYjTQkUFhYiODgYqamp0NLSgouLS6PrFFRUVCA5ORnJycmYN28eJk2a1GTczs7OKC4uFjvv7+8Pf39/kXMPHz4Uea6RkRFSU1PF7r137x7i4uJw/vx5XL58mTuvqqqK7du3w8bGBj169IC2trbIdYZRBqzQVQJXrlyBk5MTdHV1AQBeXl6NrkEwdepUAIBQKEROTs474z537pz0Evpfixcvxr/+9S/weKJ/6b9+/Rpbt27FtWvXYGFhgZUrVyIoKAhbt26VehoYRlZYodvBqKqqAqgfelZTU/PO8C2p6RoYGIgsWJOXl4d+/fqJ3Xv16lV4enoCAIqLi3Hy5EnU1tZi4MCB4PF4XBuwt7f3e1tDgmFkhRW6SsDe3h5LlixBcXExtLS0cOTIEYmFXWu0pKbr4uKCoKAgFBUVoXv37jh8+DCio6PFwjUssg4Avr6+cHV1hbe3NwoLC3H79m0UFhZCT08PcXFx4PP5UnkPhpEXrNBVAvr6+ggNDYWDgwO0tLRgZWXFLQLTnrS0tLBmzRo4ODiAiODv78910K1cuRJ2dnZwd3dv9H49PT18++23GDduHLp06QJdXV1ERES0V/IZpl2wIWMyJM0hY+Xl5ejevTtqa2vh5eUFDw8PzJo1SypxKws2ZIyRB2zImJJYu3YtbG1tMXjwYPTq1YtbVJxhGPnCaroypGyTI+Qdq+ky8oDVdBkRampq7f7M/Px8fPTRR+jWrZvYiIi8vDyMHDkS5ubmmDBhAkpLS7lrX331FczMzMDn87k1eRlG3rFCl5G57t27Y926dRLXali2bBkWLFiAu3fvwt7eHhs3bgQAxMbGIj09HXfu3MF//vMfzJ8/H7W1te2ddIZpMVboyrGKigq4u7vD2toaVlZWCA8PBwBERkbC3t4eAoEALi4uePLkCYD6Kb9z5szB6NGjYWxsjG3btmHbtm2ws7ODtbU17t27x4WbOXMmHB0dYW5ujnXr1kl8/pEjRzB8+HDY2tpiypQp3A4VK1asgKWlJaytraUyjlZTUxMjR44Uq2UTEWJjY+Ht7Q0A8PPz44agxcTEYM6cOVBRUYGFhQWMjIyQkpLS5rQwzPvGCl05FhsbC319fdy8eRO3bt3C7NmzAQDu7u64evUq0tLS4OHhIbI9e1ZWFmJjY3H16lUsX74ctbW1uHbtGnx9ffHDDz9w4VJTUxEXF4cbN25g//79YtN1s7OzERERgcTERNy4cQPDhg1DWFgYSkpKEBMTg1u3buHmzZsSZ4tVV1c3uk/ar7/+2uz3f/r0KXr06IGuXbsCqJ98UVhYCEDylOP8/Pxmx80wssLG6coxa2trBAYGIjAwEK6urhg3bhwA4Pbt21ixYgVKSkrw6tUrkT3FJk6cCFVVVfTp0wc9e/aEh4cHAEAgECA+Pp4L5+npiW7dunH/TkxMxNChQ7nrcXFxSE9Ph729PYD6glQoFEJTUxNqamrw8/ODq6urxHG3Xbt2bXRPNIbp6FhNV46ZmZkhNTUVdnZ22LJlC+bPnw8AmDVrFsLCwpCRkYFt27bh5cuX3D0N03wBQEVFhfusoqLSrGm/DYgI06dP5zaVzMzMxJ49e9CpUyckJyfDx8cHSUlJEAqFYvFKq6bbq1cvvHjxAtXV1QDqa7cNq44ZGBjgwYMHXNjGphwzjLxhha4cy8/Ph6qqKry9vbF69Wpcu3YNAPDixQv069cPRPTOBcobc/z4cVRWVqKiogLHjx+Hk5OTyHVnZ2dER0ejoKAAQH37cnZ2NsrKyvDs2TO4uLhg06ZNKC4uRnl5uci9DTVdSUdTM9LexuPxMH78eG6R84iICG7NBk9PT+zduxd1dXXIzs7G33//DaFQ2KqfBcO0J9a8IMdu3ryJZcuWQUVFBTwej1sXd8OGDXB0dISOjg6cnZ25grElhg4dCmdnZxQVFWHu3LkiTQsAwOfzsWnTJri5uXE12dWrV6Nbt26YPHkyqqqqUFdXh8DAQPTs2bNN7/nq1SuYmpqisrIS1dXVOHHiBI4cOQIHBwds3LgR3t7eWLNmDUxNTbkC2MXFBWfOnIG5uTm6dOmCnTt3olOnTm1KB8O0BzY5QoZkNTkiJCQEampqCAoKavdnyxKbHMHIA9a8wDAM045YTVeG2DTg9sVquow8YDVdhmGYdsQKXYZhmHbECl0F5+vry/XotzcTExNYWVkhMTFR5PymTZvA4/Hw6NEj7lxYWBjMzMxgbm6OgwcPNiv+ixcvYtiwYRg8eDCGDBmC169fAwDS09MhEAhgZmaGmTNncucPHDgAMzMzuLq6SukNGeY9aNj2mh3tf9T/+Ntmzpw5FBUV1eZ4WsPY2JgKCwtFzt2/f59cXFzIyMiIu5aVlUWDBw+myspKevz4MRkZGdGzZ8+ajPv58+dkbm5Od+7cISKiJ0+eUG1tLRERjRgxgn7//XciIpo9ezbt3LmTuy8hIYFcXFwkxvnfn7fMf+/s6NgHq+nKkeDgYISFhXGfd+3ahYULFwIAlixZAqFQCCsrKyxatAhE4h1wJiYmXO0yNzeX2yoHAH788UfY29vDxsYG8+fPb9HstJYICAhAWFiYyE6/MTEx8PLygrq6Onr37o2xY8fizJkzTcZz8OBBeHh4wNzcHACgq6sLFRUVPHr0CEVFRfjwww8BiC6CwzCKgBW6csTHxwdRUVHc56ioKEyfPh1A/djalJQUZGRkoKSkBCdPnmx2vPHx8bh+/TqSk5ORnp4OFRUV7N27VyxceHi4xKm7EydObNZzDh48CEtLS1hZWYmcb83iNNnZ2aioqMCYMWMwdOhQ/Otf/+LiMjAwaFFcDCNP2Iw0OWJpaYna2lrcuXMHGhoayMnJwahRowAA0dHR2LFjB16/fo3i4mIIBAK4ubk1K95Tp07hwoUL3Kyzqqoq6OjoiIULCAhAQEBAq9L+7Nkz/PDDD0hISGjV/W+rqalBUlIS/vjjD6ioqGDs2LEQCATo0aOHVOJnGFlhha6caajtampqYtq0aeDxeMjJycG6deuQkpICHR0drFixQmSRmwadO3dGXV0dAIhcJyIEBgZi8eLFTT47PDxc4u67+vr6OHXqVJP3/vnnn/j7778xePBgAPU1UqFQiAsXLkhcnMbFxaXJ+AwNDeHi4sIVshMmTMD169cxa9YsPHz4UCQuttANo1Bk3ajckQ9I6EjLzc2lQYMGkb29PaWlpRERUXp6OllaWlJNTQ09f/6cBg4cSKtWrSIi0Y40Z2dn+vXXX4mIaM2aNWRhYUFERHFxcWRra0vPnz8nIqKnT59STk6O2LNbSlJHmqRrmZmZIh1phoaGXEdaUFAQRUdHi92fnZ1Njo6O9OrVK6qurqbRo0fTyZMniYho+PDhIh1p27dv5+5jHWnskPeDtenKGWNjY2hra6OiogI2NjYA6tfVdXBwwKBBg/DJJ5/A0dFR4r2hoaEIDAyEnZ2dSE3X2dkZ8+bNg5OTE6ytrfHxxx+3apGc1uLz+Zg9ezasrKzg6OiIdevWcYvkZGRkoG/fvmL3DBw4ENOmTYNAIICtrS0cHBy4tuXt27djyZIlMDMzw+vXr+Hn59du78IwbcWmAcuQok8DNjExQXJyssRCs7lcXFwQGxsrtTRduHABGzZskDg6gk0DZuQBq+kyraarq4vx48eLTY5oCWkWuAcOHMCiRYugra0ttTgZRtpYTVeGFL2mq2hYTZeRB6ymyzAM047YkDEZUlNTe8zj8frIOh0dhZqa2mNZp4FhWPOCHOPxeHMBeANYBeAogH8DWK/sbRLq6uqPXr58yf4zkjI1NbXHVVVVre/1ZKSCFbpyile/eMEtAKcAzAHgR0QnZJuq9sHaut8P1qYtH1ibrvyaBKAvgGkAdgDw5vF4X8o2SQzDtBVr05VfWwBoA3gCQB9AAoDTMk0RwzBtxpoX5BSPxxsMoJCISmSdlvbGmhfeD9a8IB9YocvIHVbovh+s0JUPMm3TVVdXf8Tj8Ygd0j3U1dUfvfunr3gKCgpgaGjIrRtRXV0NKysrXLx4Ebm5uVBTU4NAIEBVVZXIfW5ubiILukdGRsLa2hoCgQBCoVBkRl1UVBR37cMPP8Rff/0FoP23Alq4cCEsLCxgbW2Nzz77DM+ePZMY7vz58+Dz+TAzM8NXX33VLmlj2kiWq+1ACtvVMOKg4KtpNZUvwsPDafLkyUREtHr1avr888+JiCgnJ4dbVe1Nhw4dohkzZohcKy0t5f6dnp5OpqamRET06tUr6tWrFz158oSIiH788UeaOXMmF7apFcwkqaure+e2RI05deoU1dTUEBHR0qVL6auvvhILU1NTQ6ampnTnzh2qra2lMWPGUGxsbKNxKnq+UJaDjV5gFMoXX3yBvLw8fP/99/j555/x3XffNRr2+fPnCA8Px4oVK0TOv7kQellZGbe1UMOXoqysDABQWloKPT29FqcxNzcXoaGhsLCwwOnTrev7nDBhAjp16gQAGD58uMh6xA1SUlJgbGwMc3NzqKioYM6cOWzrIgXARi8wCkVFRQVbtmyBo6Mj9uzZAy0trUbDLl26FN988w3U1dXFru3duxdr165FUVERTpyoH/6sqqqK7du3w8bGBj169IC2tjYuX77crHRVVlbi2LFj2L17N0pLSzFz5kxcunQJurq6AICjR49i7dq1Eu9NS0trNF4iwq5du+Dl5SV2TdI2SEePHm1WehnZYYUuo3BOnz4NPT09ZGRkNBrm4sWLeP78OSZMmIDc3Fyx67Nnz8bs2bNx7tw5BAcHIz4+Hq9fv8bWrVtx7do1WFhYYOXKlQgKCsLWrVvfmaa+ffti0KBB2LVrF7cO8pumTJmCKVOmtOg9gfo1krt27Yo5c+a0+F5GPil988KOHTsQGRnZZJiCggJ8+umnUnnegQMHYG5uDjMzM2zevFlimNevX2PmzJkwMzODQCBAenq6VJ7dEWRlZWH//v24fv06oqOjGy14L168iEuXLsHExASjRo3CvXv3IBQKxcI5Ozvj7t27KC4uRlpaGng8HiwsLAAA3t7eSEpKala6oqOjYW5ujqlTpyIoKAiZmZki148ePSpx00+BQNBonDt37sTZs2cRFRUlsrtyA0nbILGtixSALBuUoWQdac+ePSMTExN68uQJVVZWEp/Pp6ysLLFwO3bsoLlz5xIRUXx8PDk4OEg1HVDwDpOm8sVHH31ER48eJSKimJgYcnR0pLq6ukY70ojEO9mys7O5fycnJ5Oenh7V1dVRQUEB6erqUkFBARER/fDDDzR9+nQubHM60kpLS2nnzp3k6OhIdnZ2dPHixSbDN+bo0aNkZWVFT58+bTRMTU0NDRgwQKQj7fTp042GV/R8oSyHbB8uxUI3MjKSzMzMyM7OjhYsWEBz5swhIqJVq1bR+vXriaj+C7t06VIaPnw49e/fn06cOEFEjfd8t1RUVBT5+flxn0NCQrhnv8nFxYX++OMP7nP//v0b3WusNRT9y9VYvoiMjCQ3NzeRc25ubvTTTz+1qND9+uuvic/nk42NDTk4ONClS5e4az/99BPx+XyytramcePG0d9//81da+nohezsbEpPT292+Dfp6OiQkZER2djYkI2NDfn6+hIRUX5+Pk2YMIELFxsbSxYWFjRgwAD6f//v/zUZp6LnC2U5lKJNt7CwEMHBwUhNTYWWlhZcXFxEOhjeVFFRgeTkZCQnJ2PevHmYNGlSk3E7OzujuLhY7Ly/vz/8/f1Fzknq2EhNTRW79+1whoaGyM/Pb9O2Nx2Br68vfH19Rc799ttvACCx3baBiYkJsrKyuM/fffddo6Me5s2bh3nz5rU5rUD9Pm+tVVRUJPH82zszjx8/XuTdGPmnFIXulStX4OTkxPUUe3l5NdoWN3XqVACAUChETk7OO+M+d+6c9BLKvDedOnVCeXk5BAIBLl++LHHEQlscOHAA3377bZNtsAzTHEpR6LaEqqoqgPovaU1NzTvDt6Sma2BggLi4OO5zYx0bDR0gJiYmAIAHDx6wDpA2MjQ0xMOHD99b/DNmzMCMGTPeW/xMx6EUoxfs7e2RmJiI4uJi1NbW4siRI1KL+9y5c0hLSxM73i5wgfqdbc+fP4+ioiJUVVXh8OHD8PT0FAvn6enJjahISEhA7969WdPCeyKPo1fOnj0LW1tbdO7cGYcOHRK51tg05K+//pob7WBpaYlOnTqhpKTDrYWkHGTZoAwpdqT98ssvZGZmRkKhkObOnUsBAQFEJN6RdvnyZe4eVVVVIpJeRxoR0d69e8nU1JQGDBhA3333HXc+ODiYjh8/TkT10019fHzI1NSUrK2tKTU1VSrPbgAF7zCRZr5oT80dvfLXX3/RzZs3adasWRQVFcWdf9c05AaHDh0iZ2fnFqdP0fOFshyyfbgUv1xlZWVEVD+MZvLkybR3716pxa1oFP3L1Zp8oUijVxrMmTNHpNB9+fIlaWtr071794iIaO3atfT111+L3efu7k67d+9ucfoUPV8oy6E0bbpr165FbGwsqqqq8NFHH8HHx0fWSWLaiaKNXmlMc6Yhl5SU4Pfff8f+/fubHS8jX5Sm0N2wYQM2bNgg62QwMqAso1eaMw35yJEjcHV1hYaGRruli5EupSl0GaY55GH0SmMkTUOeOXOmSJiDBw/i66+/bnacjPxhhe5b1NTU8PLly3Z9ZlpaGubOnQsiQk1NDRYvXsx9oRctWoRLly4BqF9UJTIyEvr6+u2aPnlnb2+PJUuWoLi4GFpaWjhy5IjUhuC1pKbr4uKCoKAgFBUVoXv37jh8+HCLllo0MDDA7du3UVhYCD09PcTFxYHP53PX8/LycPv2bbi4uLToHRj5wgpdOWBhYYGrV6+iS5cuKCsrw5AhQzBp0iQYGhpiw4YN3Pqv4eHhWLlyJX7++WcZp1i+6OvrIzQ0FA4ODtDS0oKVlZVM/vzW0tLCmjVr4ODgACKCv78/t2PFypUrYWdnB3d3d1y4cAEzZ87Es2fP8NtvvyEwMBAPHz6Enp4evv32W4wbNw5dunSBrq4uIiIiuPijoqIwdepUdOnSpd3fjZEeme6R9q69sCoqKuDj44Pc3FzU1dVh/vz5CAgIQGRkJLZv347q6mr06dMH+/btQ+/evRESEoKcnBz8/fffyMnJwdKlSwHUb89SXV2NmJgYmJqaIiQkBH/99Rfu37+PoqIizJ07F//85z8BiNZ0jxw5grCwMFRXV8PU1BQRERHo0aMHVqxYgZiYGHTu3BnW1tZS7dQoKirC0KFDkZSUJNYZ9O233yI3Nxe7du1qMg5F3wurNXuklZeXo3v37qitrYWXlxc8PDwwa9as95RCxaTo+UJpyHLoBN4xNOjYsWO0YMEC7nPD1ifFxcXcuW3btnFbmaxatYrs7e3p5cuX9OjRI9LQ0KAtW7YQEdHmzZtp8eLFXDg+n0/l5eVUVlZGfD6frl+/TkT/G7ublZVFrq6u9OrVKyIiWrduHQUHB9PTp0+Jz+dTbW2tSJre9OrVK26hkrePhrG6b/vzzz/JysqK1NTUKDw8XOTakiVLSF9fnywtLenx48dN/syISOGHBr0rX0iybNkyEggEZGFhQfPnz6fXr1+3OA5lp+j5QlkO2T78HV+uu3fvUv/+/emrr76iuLg4qqurIyKixMRE+vDDD8nKyorMzc25lZ9WrVpFISEh3P2GhoaUm5tLRETnz5+nSZMmceGWL1/OhVu+fDn98MMPRPS/QvfHH38kPT09rrDk8/k0e/ZsqqmpIVtbW26MZUVFRZPv0FJ5eXk0dOhQevTokcj5uro6WrVqFa1cufKdcSj6l6s1hS7zboqeL5TlkOtpwGZmZkhNTYWdnR22bNmC+fPnAwBmzZqFsLAwZGRkYNu2bSIdXw2900D91i4Nn1VUVJrVW92AiDB9+nRu2m9mZib27NmDTp06ITk5GT4+PkhKSoJQKBSLt7q6utEFq3/99dcmn2toaAhLS0uRHWqB+j8NZ82ahWPHjjX7HRiGkT9y3ZGWn58PbW1teHt7w8LCAn5+fgCAFy9eoF+/fiCid86rb8zx48fxzTffgIhw/Phx7Nu3T+S6s7MzJk2ahC+//BL6+vqoqKjAw4cPoa+vj8rKSri4uGD06NEwMjJCeXk5evbsyd3btWvXJve9eltubi709fXRtWtXFBcXIykpCcuWLQMA3Llzh1siMCYmRqQ3m2k/shjVAgCZmZlYsGABnj59CgCIjY2FoaEhxowZw23LXlJSgl69euHGjRvtnj6m5eS60L158yaWLVsGFRUV8Hg8bvLDhg0b4OjoCB0dHTg7O6OgoKDFcQ8dOhTOzs5cR9rQoUNFrvP5fGzatAlubm5cTXb16tXo1q0bJk+ejKqqKtTV1SEwMFCkwG2NK1euYM2aNdzur//85z9hZWUFAJg/fz6ePn0KHo+HAQMG4N///nebnsUojtraWkybNg2//PILhg8fjrKyMnTuXP+VTUhI4MItXLgQBgYGskom00JyPXrhfQkJCYGamhqCgoLa/dntQdF7qdmolnqnT59GREREk6vmvX79Gvr6+khJSeGWCm2MoucLZSHXbboMI0lsbCz09fVx8+ZN3Lp1C7NnzwYAuLu74+rVq0hLS4OHh4fI7hBZWVmIjY3F1atXsXz5ctTW1uLatWvw9fXFDz/8wIVLTU1FXFwcbty4gf3794utnZCdnY2IiAgkJibixo0bGDZsGMLCwlBSUoKYmBjcunULN2/elLiDcEvb+rOzs6GqqoqJEyfC1tYWQUFBqKurE/tZWFhYvLPAZeSHXDcvvC8hISGyTgLTBtbW1ggMDERgYCBcXV0xbtw4AMDt27exYsUKlJSU4NWrVxgwYAB3z8SJE6Gqqoo+ffqgZ8+e8PDwAAAIBALEx8dz4Tw9PdGtWzfu34mJiSJNT3FxcUhPT4e9vT2A+oJUKBRCU1MTampq8PPzg6urK9zd3cXS3dK2/pqaGiQkJODatWvQ0dHBlClTsHv3bq5vA6hfv/ftqcKMfGM1XUbhdJRRLYaGhhg1ahT09PTQpUsXeHp64vr169z18vJynDlzBtOmTWt2+hnZU4pC19fXV2wF/vZiYmICKysrbojXokWLYGNjAxsbG7i4uHCdfGlpabC1tYVAIICVlRV27NjRrPjDwsJgZmYGc3NzHDx4kDvv5eUFbW1tmb23LOXn50NVVRXe3t5YvXo1rl27BkB6o1oqKytRUVGB48ePw8nJSeS6s7MzoqOjud9rRUUFsrOzUVZWhmfPnsHFxQWbNm1CcXExysvLRe5tqOlKOiTVjF1dXfHnn3+irKwMRIT4+HgMHjyYu/6f//wHH374IbS1tVv1roxsdMjmBWk7d+4ct91OY2slNLW+QmOys7Oxe/duZGRkoKysDEKhEBMnTkTPnj1x+PBhsZ1xO4qOMqpFU1MTwcHBcHBwAACMGDFCZKfiAwcOiDQ1MApCljMzIGHm0TfffEObNm3iPv/000/k7+9PRESLFy8mOzs7Gjx4MC1cuJCbofbmCvzGxsZUWFhIROI7AoSHh5NQKCRra2uaN2+eVKaKvvm8t61du5Y+//xzsfNPnjwhAwMDysvLazLu9evX0+rVq7nPvr6+IjsNvL3zQAMo+MwjSfmiPby5y4QyUvR8oSyH3DUv+Pj4ICoqivscFRWF6dOnA6jvAEtJSUFGRgZKSkpw8uTJZscbHx+P69evIzk5Genp6VBRUcHevXvFwoWHh0tsc5s4cWKznxUQEIB+/frh4MGD+Pbbb7nzmZmZGDJkCIyMjLB06dIma7mA5J0I8vPzm50OhmHkj9w1L1haWqK2thZ37tyBhoYGcnJyMGrUKABAdHQ0duzYgdevX6O4uBgCgQBubm7NivfUqVO4cOEC9+diVVUVdHR0xMIFBAQgICCgTe8QHh6OLVu2IDQ0FNu2bUNoaCj3bhkZGXjw4AE8PT0xbdo09OnTp03PYqSHjWph2oPcFbrA/2q7mpqamDZtGng8HnJycrBu3TqkpKRAR0cHK1askDgts3PnztxYxjevExECAwOxePHiJp8dHh4usoZpA319fZw6darZ79CwVoKHhwdX6DZ4c32FKVOmNBqHgYEBHjx4wH3Oy8tjC1gzjIKTu+YFoH6bkkOHDok0LZSVleGDDz6AlpYWSktLcfToUYn39u/fnxtW82aYCRMmICIiAqWlpQDq56vn5uaK3R8QECCxd7m5Be6dO3e4f7+5VkJubi6qq6sBgFtfoWGB661bt0ocTO/h4YHDhw+jqqoKT548wfnz5+Hq6tqsdHR08jSiZcyYMVwzlZGREWxtbZsVT2hoKAYOHAg+n8/NjAPYiBZFJ5c1XWNjY2hra6O0tBQ2NjYA6gfEOzg4YNCgQdDT04Ojo6PEe0NDQzF37lyEhoaKFFDOzs6YN28eNwSoS5cu+PHHH6U+k6extRKaWl8hKysLI0eOFIuLz+dj9uzZsLKyAo/Hw7p169rcI860jzdHtLRmnYS9e/ciIyMDmZmZ6Ny5Mx4/fgyAjWhRCrLsxYMSrJva1OiF5po0aRK3WHpLdJTRC8oyoqW6upp0dHQoJyfnnXHY29vTrVu3xM63dkQLkeLnC2U55LJ5QZHo6upi/PjxYuvftsSJEyfQtWvXFt3j5eWF33//Herq6q1+rqJQhhEtQMvWSbh79y6OHz8OoVCIsWPHcmtAsBEtik8umxcUSUpKikyee/jwYZk8VxaUYUQL0LJ1Eqqrq1FTU4OUlBQkJSVhypQpuH//fpvTwMgeK3QZhaDoI1oa1knYtm1bs8IbGhpi6tSpAABHR0fU1taiqKiIjWhRAqx5gVEIijyiBWh8nYSGESxv++yzz3D+/HkA9aun1dXVQUdHh41oUQIyremqqak95vF4bHaAlKmpqT2WdRqkTZFHtACS10koLi5u6DgUs3TpUsyaNQs7d+5E165dsX//fvB4PDaiRQnIdOcIhpFEVjuKSIuJiQmSk5O5IWONOXHiBO7fvy+V9uIGvr6+cHV1hbe3t9g1tnOEfGDNCwwjZc0d0eLm5ibVArcjjWhRZKymy8gdRa/pyitW05UPrKbLMAzTjtiQMUbusA7W90MZO1gVEWteYBgFxuPxugPYDaAfgM8A/BvAWSLaLst0MY1jha6cUFdXf/Ty5UtWu5MyNTW1x1VVVU0PI1BwPB5PBcAKAPMBrAawFMAgIqqVacIYiVihKydY59H70RE6j3g83gAAAgA9AGwCUArgayKKkWW6GMlYoSsnWKH7fnSQQtcewEoAIwBUA9AB8JiImt4PipEJVujKCVbovh8dodBtwOPxeADMAYwD4ExEk2WcJEYCVujKCVbovh8dqdBlFAMbp8swDNOOWKEr5woKCmBoaIiCggIA9eusWllZ4eLFi8jNzYWamhoEAgGqqqpE7nNzcxNZwer58+dwd3eHjY0N+Hw+1q9fDwCoq6vDiBEjIBAIMHjwYPj7+6OmpgZA/SItZmZm7baK1fPnzzFhwgSYm5tj5MiRyMvLkxiuYQ+yhsXEnz592i7pkwfq6uqPeDwesaPlh7q6+iNZ//4AyHa7Hnb870ATWxeFh4fT5MmTiYho9erV9PnnnxOR+NYzDQ4dOkQzZswQuRYaGkpff/01ERGVl5eTkZER/fXXX0REVFpaSkREdXV19Nlnn9G+ffu4+xISEsjFxaXRtL2trq6Onj171uzwbwoKCqLQ0FAiIoqIiCAfHx+J4VqyRRKUbIuapvIJ0zR5yQuspqsAvvjiC+Tl5eH777/Hzz//jO+++67RsM+fP0d4eDhWrFghcp7H4+HFixcgIlRWVqJLly7Q1NQEAPTo0QMA8Pr1a7x8+RL1/TEtk5ubi9DQUFhYWOD06dMtvh+o3z157ty5AIDp06fjzJkzDQUNwygNNg1YAaioqGDLli1wdHTEnj17oKWl1WjYpUuX4ptvvhFbaeof//gHPDw8oKenhxcvXmDr1q0iW9M4OjoiMzMTEyZMkLgsoCSVlZU4duwYdu/ejdLSUsycOROXLl2Crq4ugPoFw9euXSvx3rS0NLFzBQUF6NevHwBAVVUVGhoaKCkpQa9evUTC8Xg8TJw4EUQELy8vBAUFNSu9DCMXZF3VZgc11OaoKcHBwaSnp0eBgYHcubebFxITE2nq1KkSrx06dIgWLlxItbW19PDhQ+rfvz/l5eWJPKOiooI++eQTOnv2LHeuqeYFDQ0NEgqFlJaW1mTam0tDQ4Nqa2u5z0ZGRlRcXCwW7sGDB0RE9OzZMxo9erRIc8jbICd/UkrreFc+aY3t27dTREREk2Hy8/PJ09NTKs/bv38/mZmZkampKYWFhUkMU11dTTNmzCBTU1OysbGRSh6Tl7wg8wSw47+/iCa+TLdv36b+/ftTQUEBDRgwgG7evElE4gXr+vXrSV9fn4yNjalfv37UuXNnsrOzIyKiiRMnUnx8PBd26tSpdPz4cbFn/fzzz/TFF19wn5sqdOPi4mj69Olkbm5Oy5Ytoz///FPk+pEjR8jGxkbiIYmFhQX3H8HLly+pZ8+e3Jbqjdm1a5dIet8mL180aR3vo9BtT8+ePSMTExN68uQJVVZWEp/Pp6ysLLFwO3bsoLlz5xIRUXx8PDk4OLT52fKSF2SeAHb89xfRxJfpo48+oqNHjxIRUUxMDDk6OlJdXV2jHWlE4gXywoULKSgoiIiInj9/Tv3796esrCwqLi7mapPV1dX06aef0tatW7n7mtORVlpaSjt37iRHR0eys7OjixcvNhm+McuWLRPpSPPy8hILU15eznX8vXr1itzd3WnHjh2NxikvXzRpHW0pdCMjI8nMzIzs7OxowYIFNGfOHCIiWrVqFa1fv56I6vPa0qVLafjw4dS/f386ceIEETXeadtSUVFR5Ofnx30OCQnhnv0mFxcX+uOPP7jP/fv3b3bnaWPkJS+wjjQ5t3v3bmhoaGDy5PrJRZ6entDW1sbPP//conhWrlyJGzduwMrKCg4ODvi///s/WFhYoKioCB9//DGsra0hEAhgZGSEBQsWtCjuHj16YP78+bh06RIOHDgADQ2NFt3fYNmyZUhKSoK5uTl++uknbNy4EUB9W+/EiRMBAI8fP8aHH34Ia2tr2NrawszMDJ9//nmrnteRFBYWIjg4GElJSbh8+TLu3r3baNiKigokJyfj4MGDzWovd3Z25obvvXns2LFDLOzDhw9haPi/2clGRkbIz89/ZzhDQ0OJ4RQR60iTc76+vvD19RU599tvvwGAxJ1rG5iYmCArK4v73LdvX5w5c0Ys3KBBg5CamiqVtALAwIEDW32vlpaWxDS+udX5gAEDJHbCMU27cuUKnJycuE5OLy8vJCUlSQzbsPW7UChETk7OO+M+d+6c9BLaAbCargLr1KkTysvLJU6OkIYDBw5g0aJFYtuGM8pNVVUVQH3+apgo05SW1HQNDAzw4MED7nNeXh43YqWpcA8ePJAYTiHJun2DHfUHpNhBoki90QUFBTRs2DCysbEhPp9PK1eu5O7x9/engQMH0pAhQ+jTTz+lkpKSFqcNctKOJ62jtfkkPz+fDAwMqKioiGpqasjZ2bnRNt3Lly9z96mqqhKR9Np0S0pKyNjYWKQj7fbt22Lhtm/fLtKRNnz48DY/W17ygswTwI7//iIUtFe6rb3R1dXVVFlZyf3b3t6eEhMTiYjo1KlTVFNTQ0RES5cupa+++qrF6ZOXL5q0jrbkk19++YXMzMxIKBTS3LlzKSAggIjat9AlItq7dy+ZmprSgAED6LvvvuPOBwcHcyNqXr16RT4+PmRqakrW1taUmpra5ufKS16QeQLY8d9fRCu+TMrWG11eXk4CgUDi6Idjx47RtGnTWpw+efmiSetoS6FbVlZGREQ1NTU0efJk2rt3b6vjUkTykhdYm66CUqbe6OfPn8PGxga9e/eGs7MzRo4cKXIvEWHXrl2YMGHCO9PONG7t2rWwtbXF4MGD0atXL/j4+Mg6SR0SG72goJSpN7pnz55IT09HSUkJPDw8cOvWLVhZWXHXQ0ND0bVrV8yZM6dd06VsNmzYgA0bNsg6GR0eK3Q7gNb0RhcXF4ud9/f3h7+/v8g5AwMDxMXFcZ/f1RttYmICQHJvtLa2NkaPHo0zZ85whe7OnTtx9uxZnDt3rlUL8TCMvGHNCwrK3t4eiYmJKC4uRm1tLY4cOSK1uM+dO4e0tDSx4+0CFwBcXFxw/vx5FBUVoaqqCocPH4anp6dYOE9PT0RGRgIAEhIS0Lt3b/Tt2xcFBQWoqKgAUN8MEhcXBz6fDwA4duwYtm7dihMnTuCDDz6Q2vsx0qOmpiaT52ZmZsLJyQmWlpawtLQUGV4m71hNV0Hp6+sjNDQUDg4O0NLSgpWVVatngrWFlpYW1qxZAwcHBxAR/P39ucXTV65cCTs7O7i7u8PPzw9//PEHzMzM0K1bN+zevRsAcPfuXSxZsgQ8Hg+1tbWYPn06Jk2aBKC+Zv3BBx9g7NixAABbW1uu4GY6rtraWkybNg2//PILhg8fjrKyMnTurDhFGdsjTU60Zo+08vJydO/eHbW1tfDy8oKHhwdmzZr1nlKomJRtj7Sm8klFRQV8fHyQm5uLuro6zJ8/HwEBAYiMjMT27dtRXV2NPn36YN++fejduzdCQkKQk5ODv//+Gzk5OVi6dCkAIDIyEtXV1YiJiYGpqSlCQkLw119/4f79+ygqKsLcuXPxz3/+E0B9Tffly5cAgCNHjiAsLAzV1dUwNTVFREQEevTogRUrViAmJgadO3eGtbU19u/f36afwenTpxEREdHiv+7kJS+w5gUFxnqjmTfFxsZCX18fN2/exK1btzB79mwAgLu7O65evYq0tDR4eHiILIKflZWF2NhYXL16FcuXL0dtbS2uXbsGX19f/PDDD1y41NRUxMXF4caNG9i/f7/Y1PHs7GxEREQgMTERN27cwLBhwxAWFoaSkhLExMTg1q1buHnzJrZu3SqW7urqaomjZQQCAX799Vex8NnZ2VBVVcXEiRNha2uLoKAg1NXVSemn+P4pTp2cEcN6o5k3WVtbIzAwEIGBgXB1dcW4ceMAALdv38aKFStQUlKCV69eYcCAAdw9EydOhKqqKvr06YOePXvCw8MDACAQCBAfH8+F8/T0RLdu3bh/JyYmYujQodz1uLg4pKenw97eHkB9QSoUCqGpqQk1NTX4+fnB1dUV7u7uYunu2rVri9bTqKmpQUJCAq5duwYdHR1MmTIFu3fvhp+fX/N/WDLEaroMoyTMzMyQmpoKOzs7bNmyBfPnzwcAzJo1C2FhYcjIyMC2bdu45gDgfyNbgPodSho+q6ioNGukSwMiwvTp07lO18zMTOzZswedOnVCcnIyfHx8kJSUBKFQKBZvS2u6hoaGGDVqFPT09NClSxd4enri+vXrLfpZyRIrdJlGyVvP9KZNm2Bqagoej4dHj+RjY1d5kp+fD1VVVXh7e2P16tW4du0aAODFixfo168fiKjVHZHHjx9HZWUlKioqcPz4cTg5OYlcd3Z2RnR0NLdrdUVFBbKzs1FWVoZnz57BxcUFmzZtQnFxMcrLy0XubajpSjok1YxdXV3x559/oqysDESE+Ph4DB48uFXvJQuseYGRK031TI8ZMwbTpk3DRx99JONUyqebN29i2bJlUFFRAY/H45qeNmzYAEdHR+jo6MDZ2ZkrGFti6NChcHZ25jrS3mxaAAA+n49NmzbBzc2Nq8muXr0a3bp1w+TJk1FVVYW6ujoEBgaiZ8+ebXpPTU1NBAcHw8HBAQAwYsQIzJs3r01xtic2ekFOvGv0AuuZ/h8TExMkJyejb9++74xPXnqspaU1o1zaKiQkBGpqagq/Aai85AXWvKAgWM80wygH1rygIFjPtGL0TCujkJAQWSdBqbCaroJgPdMMoxxYTVdB5OfnQ1tbG97e3rCwsOBqftLqmf7mm29ARDh+/Dj27dsnct3Z2RmTJk3Cl19+CX19fVRUVODhw4fQ19dHZWUlXFxcMHr0aBgZGaG8vFyko6SlNV1XV1esWbMGZWVl6N69O+Lj47kOE4ZRBqymqyBu3ryJ4cOHQyAQwM/PT6xnWigUwsjIqFVxN/RMCwQCzJgxo8meaWtrazg4OOD27dsoLS2Fu7s7rK2tMWzYMKn3TA8ZMgSqqqpcz/T69ethYGCAhw8fYujQodySlUzL+Pr64tChQzJ5tomJCaysrJCYmMidCw0NxcCBA8Hn87lO3Kbk5eVh5MiRMDc3x4QJE1BaWgqgfiElS0tLbu0PuSXrVdTZUX9ARtv1vLnLhDKCnOwWIK1DGvlkzpw5FBUV1eZ4WsPY2Fhkx5A9e/bQ5MmT6fXr10RE9OjRo3fG4e3tTXv27CEiopUrV9Ly5cu5a03tiCIveYHVdBlGgQUHByMsLIz7vGvXLixcuBAAsGTJEgiFQlhZWWHRokUNhbYIExMTbqJJbm6uSC3xxx9/hL29PWxsbDB//vwW9QM017Zt2xAaGsqNxe7Tp0+T4YkIsbGx8Pb2BgD4+fkhOjpa6ul6n1ih28GFhIQo/PjLjszHxwdRUVHc56ioKEyfPh1A/e82JSUFGRkZKCkpwcmTJ5sdb3x8PK5fv47k5GSkp6dDRUUFe/fuFQsXHh4usZN04sSJzXrO3bt3cfz4cQiFQowdO1ZsuOLbnj59ih49eqBr164A6hfHLywsbPZ7yQPWkcYwCszS0hK1tbW4c+cONDQ0kJOTg1GjRgEAoqOjsWPHDrx+/RrFxcUQCARwc3NrVrynTp3ChQsXuPb9qqoq6OjoiIULCAhAQEBAq9NfXV2NmpoapKSkICkpCVOmTMH9+/dbHZ8iYDVdJSJPHSStXSehsU6VsLAwmJmZwdzcHAcPHuTOe3l5QVtbW2bvLQ8aaruHDx/GtGnTwOPxkJOTg3Xr1iE2NhY3b97E3LlzRYYTNujcuTM3+eTN60SEwMBAbphgdnY21q5dK3Z/W2u6hoaGXIeoo6MjamtrUVRU1Gj4Xr164cWLF6iurgZQv+Gpnp5es54lL1ihy0jNuXPnuIVQxowZg/j4eBgbGzf7/r179yIjIwOZmZm4ffs2/vGPfwCon6W2e/duZGRk4NKlS1i+fDmeP38OADh8+LDESRkdibe3Nw4dOiTStFBWVoYPPvgAWlpaKC0txdGjRyXe279/f24c9JthJkyYgIiICG5kQElJCXJzc8XuDwgIkLhQzalTp5qV9s8++wznz58HUD/Rp66ujqtRSxqFwOPxMH78eO4/2YiICInbQ8kzVujKKUXvILGzs2tRgQs03qkSExMDLy8vqKuro3fv3hg7dizOnDkj9TQrKmNjY2hra6OiogI2NjYAwA3tGzRoED755BM4OjpKvDc0NBSBgYGws7MTqek6Oztj3rx5cHJygrW1NT7++ONWLZTzLkuXLsXZs2cxZMgQzJw5E/v37wePx0NxcbHEfA0AGzduxPbt22Fubo4rV64oXp+ErIdPsIMaMhe96c8//6ShQ4dyn8eMGUN//PEHEREVFxcTEVFdXR15eXnRb7/9RkSiQ4HeHJrz5jCa8+fP05w5c6i2tpaIiBYsWEC//PILvW3Lli1kY2MjdkyYMEEs7NvPa855SbS0tOjbb78lOzs7GjNmDF2/fp2IiL744guKjIzkwq1cuZLCwsK4z00NgYKcDBOS1vF2PlE0zc0Pv/32G23ZsqXF8SvCkDHWkSanFL2DpDU6YqdKR6Orq4vx48dj27ZtYmvyvqm5+flNCQkJCAgIgK6ubluS+N6xQleONXSQaGpqinWQpKSkQEdHBytWrGhVB8nixYubfHZ4eDgiIiLEzuvr6ze7va6lGutUMTAwENliOy8vDy4uLu8lDcz7lZKS8t7iHjNmDDIyMt5b/NLC2nTlmCJ3kDSlsWmajXWqeHh44PDhw6iqqsKTJ09w/vx5uLq6tjkdDCMLrNCVY4rcQdLYOglNdZA01qnC5/Mxe/ZsWFlZwdHREevWrWvzGg+KSk1N7TGPxwM7Wn6oqak9lvXvD2A7R8gNWewIIE3N3c3hxIkTuH//vlTbi319feHq6spNDX2TvOwWwDANWE2XkYqGDpI3V4+SxM3NTaoFrpeXF37//Xeoq6tLLU6GeZ9YTVdOKHpNV16xmi4jb1hNl2EYph2xQpdhGKYdsXG6cuK/vdJNLybKtJi89FgzTAPWpivHeDxeKIC+AHIBLAYwlYiSZJooOcHj8foBiEb9z+YsgOlENE6miWKYZmCFrpzi8XgfoL5ASQHQG8CnAAqJqFaW6ZIXPB6PB0AdwHYA1gD6AHAjoqZXwWYYGWNtuvLr/wD0AKAH4AmAGwDWyTRF8uUTAI8BGAMoBqANYKNMU8QwzcBqunKKx+PdAtAd9X9CXwZwmYgeyjZV8oXH4/UEMByAA4BJAAYB6MHG3jHyjBW6DMMw7Yg1LzAMw7QjmQ4ZU1dXf/Ty5Us2TErK1NTUHldVVTW9CIICYfmk9ZQtLygDmTYvsKmv74eyTX1l+aT1lC0vKAPWvMAwDNOOWKHLMAzTjlihyzAM046UvtDdsWMHIiMjmwxTUFCATz/9VCrPO3DgAMzNzWFmZobNmzdLDPP69WvMnDkTZmZmEAgESE9Pl8qzmeZj+YKRGVluRQwF3076bc+ePSMTExN68uQJVVZWEp/Pp6ysLLFwO3bsoLlz5xIRUXx8PDk4OEg1HZCTraaldSh6PpFlvlC2vKAMh9LUdHfv3g1zc3MIhUL4+/vD19cXABASEoINGzYAAEaPHo1ly5ZhxIgRGDBgAE6ePAkAyM3NbXSzxJY4c+YMxo4dC11dXairq8PLywsxMTFi4WJiYjB37lwA9TuYPnr0CI8ePWrz8xlxLF8w8kYplnYsLCxEcHAwUlNToaWlBRcXFxgaGkoMW1FRgeTkZCQnJ2PevHmYNGlSk3E7OzujuLhY7Ly/vz/8/f1Fzj18+FDkuUZGRkhNFV9/5e1whoaGyM/Pf+f+YkzLsHzByCOlKHSvXLkCJycn6OrqAqjfNyspSfIKiA270gqFQuTk5Lwz7nPnzkkvoUy7YvmCkUdKUei2hKqqKgCgU6dOqKmpeWf4ltRoDAwMEBcXx33Oy8tDv379xO41MDDAgwcPYGJiAgB48OCBxHBM+2H5gmkvSlHo2tvbY8mSJSguLoaWlhaOHDkitczakhqNi4sLgoKCUFRUhO7du+Pw4cOIjo4WC+fp6YnIyEg4OTkhISEBvXv3Zn9CvgcsXzDySCkKXX19fYSGhsLBwQFaWlqwsrKChoZGu6dDS0sLa9asgYODA4gI/v7+XEfMypUrYWdnB3d3d/j5+eGPP/6AmZkZunXrht27d7d7WjsCli8YeaQ0ay+Ul5eje/fuqK2thZeXFzw8PDBr1iypxK1olG2+fVvySUfPF8qWF5SB0gwZW7t2LWxtbTF48GD06tULPj4+sk4SIwdYvmDkjdLUdJn/UbbaDcsnradseUEZKE1NV1rU1NRk8tzMzEw4OTnB0tISlpaWePDgAYD6nu6RI0fC3NwcEyZMQGlpqUzSx/yPLPJIfn4+PvroI3Tr1k1sdASjWFihKwdqa2sxbdo0hIWFITMzE1euXIGOjg4AYNmyZViwYAHu3r0Le3t7bNzI9l7siLp3745169Y1um4DozjkutCtqKiAu7s7rK2tYWVlhfDwcABAZGQk7O3tIRAI4OLigidPngCon9o5Z84cjB49GsbGxti2bRu2bdsGOzs7WFtb4969e1y4mTNnwtHREebm5li3TvImu0eOHMHw4cNha2uLKVOm4MWLFwCAFStWwNLSEtbW1pg5c2ab3/Ps2bPg8/kYPnw4AEBDQwPq6uogIsTGxsLb2xsA4OfnJ3GoUUfWUfKIpqYmRo4cKbO/xBgpkuXCD3jHQibHjh2jBQsWcJ+fPXtGRETFxcXcuW3bttFXX31FRESrVq0ie3t7evnyJT169Ig0NDRoy5YtRES0efNmWrx4MReOz+dTeXk5lZWVEZ/Pp+vXrxMRkaqqKhERZWVlkaurK7169YqIiNatW0fBwcH09OlT4vP5VFtbK5KmN7169YpsbGwkHsePHxcL//3339OMGTNowoQJJBAIaNmyZVRbW0tFRUVkbGzMhaupqaEePXo0+TMjIqVb5KSpfNJR8kiDyMhIkfd9F2XLC8pwyPU4XWtrawQGBiIwMBCurq4YN24cAOD27dtYsWIFSkpK8OrVKwwYMIC7Z+LEiVBVVUWfPn3Qs2dPeHh4AAAEAgHi4+O5cJ6enujWrRv378TERAwdOpS7HhcXh/T0dNjb2wMAqqurIRQKoampCTU1Nfj5+cHV1RXu7u5i6e7atSvS0tKa/Z41NTVISEjAtWvXoKOjgylTpmD37t0S42ZEdZQ8wigPuW5eMDMzQ2pqKuzs7LBlyxbMnz8fADBr1iyEhYUhIyMD27Ztw8uXL7l7GqZzAoCKigr3WUVFpVnTOxsQEaZPn460tDSkpaUhMzMTe/bsQadOnZCcnAwfHx8kJSVBKBSKxVtdXQ2BQCDx+PXXX8WeZWhoiFGjRkFPTw9dunSBp6cnrl+/jl69euHFixeorq4GUL8gip6eXvN/gB1AR8kjjPKQ65pufn4+tLW14e3tDQsLC/j5+QEAXrx4gX79+oGI3rkQdWOOHz+Ob775BkSE48ePY9++fSLXnZ2dMWnSJHz55ZfQ19dHRUUFHj58CH19fVRWVsLFxQWjR4+GkZERysvL0bNnT+7eltZiXF1dsWbNGpSVlaF79+6Ij4+Hg4MDeDwexo8fj0OHDmH27NmIiIiAp6dnq95XWXWUPMIoD7kudG/evIlly5ZBRUUFPB6PW/90w4YNcHR0hI6ODpydnVFQUNDiuIcOHQpnZ2cUFRVh7ty5In82AgCfz8emTZvg5ubG1VJWr16Nbt26YfLkyaiqqkJdXR0CAwNFvkytoampieDgYDg4OAAARowYgXnz5gEANm7cCG9vb6xZswampqY4dOhQm56lbDpKHnn16hVMTU1RWVmJ6upqnDhxAkeOHOHyDKM4OuTkiJCQEKipqSEoKKjdn90elG1AvCzyibLkEWXLC8pArtt0GYZhlE2HrOkqO2Wr3bB80nrKlheUAavpMgzDtCNW6DIMw7QjpSh0fX19Zdarb2JiAisrKyQmJgJo3QI1r1+/xhdffIGBAwdi0KBB+Pe//81d++qrr2BmZgY+n4/z589z552cnNC9e3ckJydL/6WUkDzlkU2bNsHU1BQ8Hq/Zu/02lq8SEhJgaWkplV2LmfahFIWurJ07dw5OTk4AWrdAzfr169GlSxfcuXMHWVlZmDJlCgAgNjYW6enpuHPnDv7zn/9g/vz5qK2tBQAkJibCzs7u/b0UI1Vv5pExY8YgPj4exsbGzb6/sXw1ZswYnDp16r2kmXk/5K7QDQ4ORlhYGPd5165dWLhwIQBgyZIlEAqFsLKywqJFiyCpc8XExISrPeTm5orUAH788UfY29vDxsYG8+fPb9Hso+Ygat0CNTt37kRoaCj3uXfv3gCAmJgYzJkzByoqKrCwsICRkRFSUlKkmmZFpMh5BADs7OxaVOC2Nl8x8knuCl0fHx9ERUVxn6OiojB9+nQA9WMnU1JSkJGRgZKSEpw8ebLZ8cbHx+P69etITk5Geno6VFRUsHfvXrFw4eHhEqdmTpw48Z3PePr0KXr06IGuXbsCqN/dtbCwsMl7nj9/DiLCunXrMGzYMLi5ueH+/fsA6qf9GhoacmGNjIyQn5/f7HdWVoqcR1qjNfmKkV9yNyPN0tIStbW1uHPnDjQ0NJCTk4NRo0YBAKKjo7Fjxw68fv0axcXFEAgEcHNza1a8p06dwoULF7hZRVVVVdyatW8KCAhAQECA9F7oHWpqalBYWIjBgwdj48aNOHz4MHx9ffHHH3+0WxoUTUfLI4xykbtCF/hfTUZTUxPTpk0Dj8dDTk4O1q1bh5SUFOjo6GDFihUii5g06Ny5M+rq6gBA5DoRITAwEIsXL27y2eHh4YiIiBA7r6+v/862szcXqOnatWuzFqjp1asX1NXVMXXqVADAlClT8PnnnwOor9E07CAB1HemSGsLcUWnqHmkNVqTrxj5JXfNCwDg7e2NQ4cOifzZWFZWhg8++ABaWlooLS3F0aNHJd7bv39/XL9+HQBEwkyYMAERERFcr29JSQlyc3PF7g8ICOBWjXrzaM6X6c0FagCILFCTn5/PLTv49j2ffvopNzIhISEBfD4fQP1ygnv37kVdXR2ys7Px999/QygUvjMdHYGi5pF3kTQKoal8xSgeuSx0jY2Noa2tjYqKCtjY2ACoXzfVwcEBgwYNwieffAJHR0eJ94aGhiIwMBB2dnYitRhnZ2fMmzcPTk5OsLa2xscff9yqRVDeZePGjdi+fTvMzc1x5coVbu5+YWEhOneW/IfFxo0bsXnzZlhbW2PVqlX45ZdfAAAuLi4YPHgwzM3N4eHhgZ07d6JTp05ST7MiUuQ8sn79ehgYGODhw4cYOnQo91dOcXGxxI4/oPF8xSgeNg24jUxMTJCcnIy+ffs2GW7r1q0wMjKS6sLko0ePxoYNGzBixAiR88o29VPR80lz88iJEydw//79FrcX5+bmwtXVFVlZWWLXlC0vKAO5rOkqEl1dXYwfP54b+N6YxYsXS7XAdXJywv3797kebUZ+NTePuLm5tbjATUhIwCeffAJdXd22JJFpR6ymq4SUrXbD8knrKVteUAaspsswDNOOZDpkTE1N7TGPx+sjyzQoIzU1tceyToM0sXzSesqWF5SBTJsXGIZhOhrWvMAwDNOOWKHLMAzTjlihyzAM045YocswDNOOWKHLMAzTjlihyzAM045YocswDNOOWKHLMAzTjlihyzAM045YocswDNOOWKHLMAzTjlihyzAM047+P4WlnM15KJQPAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAV0AAADnCAYAAAC9roUQAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8/fFQqAAAACXBIWXMAAAsTAAALEwEAmpwYAABJ80lEQVR4nO3dezyVWf8//tfWAaUDURFStkRiE4rSdDBRGTQpdMRjKp3c39+Mu3Q3NVTT1KR7JtWdponO6lFxm+msaMaMdNCQRjQVo1CRklOO798fPq673d7ksLMP1vPxuB6P9nWta13r2pbVso48IgLDMAzTMZSknQCGYZjOhBW6DMMwHYgVugzDMB2IFboMwzAdiBW6DMMwHYgVugzDMB2oq7QT0Jmpqqo+ffPmzQBpp6OzUFFReVZZWTlQ2ulgOjceG6crPTwej9j333F4PB6IiCftdDCdG2teYBiG6UCs0GUYhulArNBlGIbpQKzQZRiG6UCs0JVB+fn50NPTQ35+PgCguroaZmZm+O2335CTkwMVFRUIBAJUVlYCAAwMDGBmZgaBQACBQIAXL14AAC5dugRLS0t07doVx48fF3qGt7c3+vfvj+HDhwudP3r0KPh8PpydnTvgTRuEh4dj+PDhGDFiBBYsWAAASExM5N5HIBBATU0NO3bsELn36tWr6N27Nxdu+fLlHZZuhmkTImKHlI6Gr1+8sLAwmjlzJhERbdiwgT777DMiIsrOziZjY2OhsIMHD6aCggKROB48eEB37tyh+fPnU1RUlNC1hIQESklJEYmr8ZqTk1OTaXtXfX09vXz5ssXh3/bLL7/Q2LFjqaysjIiInj59KhLmzZs3pKGhQbm5ue1K6/9931L/ubOjcx+spiujli9fjtzcXHz33Xf48ccf8e2337Y6DkNDQ4wcORJKSqI/5gkTJkBDQ6NdaczJyUFISAiMjY1x/vz5NsWxe/durFmzBj179gQADBggOmz53LlzMDc3h56eXrvSyzCygBW6MkpJSQk7duzA559/jo0bN0JdXb3JsDweD9OmTYOlpSW2bNnyQdNVUVGBw4cPY/LkyfDw8ECfPn3w+++/w9vbGwBw6tQpoWaBtw9xsrKycOPGDYwZMwZ2dnaIi4sTCXP06FHMnTu3yTTduHEDAoEAkyZNQlJSkkTek2E+FDYjTYadP38e2traSE9PbzZcYmIidHV18erVK8yYMQO6urqYN2/eB0nTwIEDMXz4cOzbtw8WFhYi1z08PODh4dHi+Gpra5GXl4ekpCQ8evQIEyZMwJ9//ok+ffoAAF6/fo3Lly9j//79Yu+3srLC33//jV69euHatWuYNWsWMjIy0Lt377a9IMN8YKymK6MyMzNx5MgRpKSkIDo6utmCV1dXFwDQt29fzJ07F8nJyR8sXdHR0TAyMsKsWbMQFBSEjIwMoeutrenq6elh5syZUFJSAp/Ph6GhIe7fv89dP336NBwdHblC+F29e/dGr169AAB2dnYwMDAQup9hZA0rdGWUv78/tm3bBm1tbWzfvh3+/v4gEp0yXF5ejtevXwNoGOXw888/Y+TIkR8sXY6Ojjh69Chu3bqFoUOHYtGiRbCxscHvv/8OoKGmm5qaKvYQ59NPP8WVK1cAAM+ePcPDhw8xdOhQ7vr7mhaePn3KfS/379/Hw4cPYWhoKKG3ZZgPQNo9eZ35QBOjFyIjI8nFxUXonIuLC/3www8ioxcePnxIFhYWNHLkSDI1NaXPP/+camtriaihZ3/QoEHUo0cP0tDQoEGDBnH3ffLJJzRw4EDq2rUrDRo0iLZv385da+3ohaysLEpLS2tx+LdVV1eTj48PmZqa0siRI+nkyZPctfz8fOrXrx9VVVUJ3bNnzx7as2cPERHt3LmTTE1NycLCgkaNGkVnzpxp8llgoxfYIQMHW/BGitqy4E1OTg6cnZ2RmZn5gVLVMPZ1y5YtuHDhwgd7hjSwBW8YWcCaF+RMly5dUFZWJjQ5QpKOHj2KZcuWtXs4GcMw4rGarhSxpR07FqvpMrKA1XQVXHh4OCIjI5sNk5+fjxkzZkjkeUePHoWRkRH4fD62b9/ebNjr16+jS5cuQlOUo6KiYG5uDoFAgPHjx+PBgwcSSRfDyApW05UiRavpvnr1CpaWlrhx4wbU1NQwatQoxMTEwNjYWCRsbW0tHB0d0aNHDyxYsABeXl6orq6Gjo4O7t27By0tLezatQvXr1/H4cOHJZI+VtNlZAGr6SqIAwcOwMjICDY2NvD394ePjw8AIDg4mJulNmHCBKxevRpjxozB0KFDcfbsWQANnXPvLnzTFhcuXMCkSZOgpaUFVVVVeHp6IiYmRmzYbdu2cYvuNGrs3S0tLQUAlJSUQFtbu93pYhhZwmakKYCCggKsW7cOt2/fhrq6OpycnJpcp6C8vBzJyclITk7GokWLMH369GbjdnR0RFFRkch5f39/+Pv7C5178uSJ0HP19fVx+/ZtkXsfPnyIuLg4XLlyBdeuXePOKysrY8+ePbCwsEDv3r2hoaEhdJ1hFAErdBXA9evX4eDgAC0tLQCAp6dnk2sQzJo1CwBgY2OD7Ozs98Z9+fJlySX0/6xYsQL//ve/weMJ/6VfU1ODXbt24datWzA2Nsb69esRFBSEXbt2STwNDCMtrNDtZJSVlQE0DD2rra19b/jW1HR1dXWFFqzJzc3FoEGDRO69ceMG3N3dAQBFRUU4e/Ys6urqMGzYMPB4PK4N2MvL64OtIcEw0sIKXQVga2uLlStXoqioCOrq6jh58qTYwq4tWlPTdXJyQlBQEAoLC6GmpoYTJ04gOjpaJFzjIusA4OPjA2dnZ3h5eaGgoAD37t1DQUEBtLW1ERcXBxMTE4m8B8PIClboKgAdHR2EhITAzs4O6urqMDMz4xaB6Ujq6urYuHEj7OzsQETw9/fnOujWr18Pa2truLq6Nnm/trY2vv76a0yePBndunWDlpYWIiIiOir5DNMh2JAxKZLkkLGysjKoqamhrq4Onp6ecHNzw/z58yUSt6JgQ8YYWcCGjCmITZs2wdLSEiNGjEC/fv24RcUZhpEtrKYrRYo2OULWsZouIwtYTZcRoqKi0uHPzMvLw0cffYSePXuKjIjIzc3F2LFjYWRkhKlTp6KkpIS79sUXX4DP58PExIRbk5dhZB0rdBmpU1NTw+bNm8Wu1bB69WosWbIEf/31F2xtbbF161YAwMWLF5GWlob79+/jv//9LxYvXoy6urqOTjrDtBordGVYeXk5XF1dYW5uDjMzM4SFhQEAIiMjYWtrC4FAACcnJzx//hxAw5TfhQsXYsKECRg8eDB2796N3bt3w9raGubm5nj48CEXbt68ebC3t4eRkRE2b94s9vknT57E6NGjYWlpCQ8PD26HirVr18LU1BTm5uYSGUfbp08fjB07VqSWTUS4ePEivLy8AAB+fn7cELSYmBgsXLgQSkpKMDY2hr6+Pm7evNnutDDMh8YKXRl28eJF6Ojo4M6dO7h79y4WLFgAAHB1dcWNGzeQmpoKNzc3oe3ZMzMzcfHiRdy4cQNr1qxBXV0dbt26BR8fH3z//fdcuNu3byMuLg5//PEHjhw5IjJdNysrCxEREUhMTMQff/yBUaNGITQ0FMXFxYiJicHdu3dx584dsbPFqqurm9wn7aeffmrx+7948QK9e/dG9+7dATRMvigoKAAgfspxXl5ei+NmGGlh43RlmLm5OQIDAxEYGAhnZ2dMnjwZAHDv3j2sXbsWxcXFqKqqEtpTbNq0aVBWVsaAAQPQt29fuLm5AQAEAgHi4+O5cO7u7ujZsyf378TERFhZWXHX4+LikJaWBltbWwANBamNjQ369OkDFRUV+Pn5wdnZWey42+7duze5JxrDdHaspivD+Hw+bt++DWtra+zYsQOLFy8GAMyfPx+hoaFIT0/H7t278ebNG+6exmm+AKCkpMR9VlJSatG030ZEhDlz5nCbSmZkZODgwYPo0qULkpOT4e3tjaSkJNjY2IjEK6mabr9+/fD69WtUV1cDaKjdNq46pquri8ePH3Nhm5pyzDCyhhW6MiwvLw/Kysrw8vLChg0bcOvWLQDA69evMWjQIBDRexcob0psbCwqKipQXl6O2NhYODg4CF13dHREdHQ08vPzATS0L2dlZaG0tBQvX76Ek5MTtm3bhqKiIpSVlQnd21jTFXc0NyPtXTweD1OmTOEWOY+IiODWbHB3d8ehQ4dQX1+PrKws/P3337CxsWnTd8EwHYk1L8iwO3fuYPXq1VBSUgKPx+PWxd2yZQvs7e2hqakJR0dHrmBsDSsrKzg6OqKwsBC+vr5CTQsAYGJigm3btsHFxYWryW7YsAE9e/bEzJkzUVlZifr6egQGBqJv377tes+qqioYGhqioqIC1dXVOHPmDE6ePAk7Ozts3boVXl5e2LhxIwwNDbkC2MnJCRcuXICRkRG6deuGvXv3okuXLu1KB8N0BDY5QoqkNTkiODgYKioqCAoK6vBnSxObHMHIAta8wDAM04FYTVeK2DTgjsVquowsYDVdhmGYDsQKXYZhmA7ECl055+Pjw/XodzQDAwOYmZkhMTFR6Py2bdvA4/Hw9OlT7lxoaCj4fD6MjIxw7NixFsX/22+/YdSoURgxYgRGjhyJmpoaAEBaWhoEAgH4fD7mzZvHnT969Cj4fD6cnZ0l9IYM8wE0bnvNjo4/Gr7+9lm4cCFFRUW1O562GDx4MBUUFAide/ToETk5OZG+vj53LTMzk0aMGEEVFRX07Nkz0tfXp5cvXzYb96tXr8jIyIju379PRETPnz+nuro6IiIaM2YM/fLLL0REtGDBAtq7dy93X0JCAjk5OYmN8/++b6n/3NnRuQ9W05Uh69atQ2hoKPd53759WLp0KQBg5cqVsLGxgZmZGZYtWwYi0Q44AwMDrnaZk5PDbZUDADt37oStrS0sLCywePHiVs1Oa42AgACEhoYK7fQbExMDT09PqKqqon///pg0aRIuXLjQbDzHjh2Dm5sbjIyMAABaWlpQUlLC06dPUVhYiPHjxwMQXgSHYeQBK3RliLe3N6KiorjPUVFRmDNnDoCGsbU3b95Eeno6iouLcfbs2RbHGx8fj5SUFCQnJyMtLQ1KSko4dOiQSLiwsDCxU3enTZvWouccO3YMpqamMDMzEzrflsVpsrKyUF5ejokTJ8LKygr//ve/ubh0dXVbFRfDyBI2I02GmJqaoq6uDvfv30evXr2QnZ2NcePGAQCio6MRHh6OmpoaFBUVQSAQwMXFpUXxnjt3DlevXuVmnVVWVkJTU1MkXEBAAAICAtqU9pcvX+L7779HQkJCm+5/V21tLZKSkvDrr79CSUkJkyZNgkAgQO/evSUSP8NICyt0ZUxjbbdPnz6YPXs2eDwesrOzsXnzZty8eROamppYu3at0CI3jbp27Yr6+noAELpORAgMDMSKFSuafXZYWJjY3Xd1dHRw7ty5Zu/9888/8ffff2PEiBEAGmqkNjY2uHr1qtjFaZycnJqNT09PD05OTlwhO3XqVKSkpGD+/Pl48uSJUFxsoRtGrki7UbkzHxDTkZaTk0PDhw8nW1tbSk1NJSKitLQ0MjU1pdraWnr16hUNGzaMvvrqKyIS7khzdHSkn376iYiINm7cSMbGxkREFBcXR5aWlvTq1SsiInrx4gVlZ2eLPLu1xHWkibuWkZEh1JGmp6fHdaQFBQVRdHS0yP1ZWVlkb29PVVVVVF1dTRMmTKCzZ88SEdHo0aOFOtL27NnD3cc60tgh6wdr05UxgwcPhoaGBsrLy2FhYQGgYV1dOzs7DB8+HJ988gns7e3F3hsSEoLAwEBYW1sL1XQdHR2xaNEiODg4wNzcHB9//HGbFslpKxMTEyxYsABmZmawt7fH5s2buUVy0tPTMXDgQJF7hg0bhtmzZ0MgEMDS0hJ2dnZc2/KePXuwcuVK8Pl81NTUwM/Pr8PehWHai00DliJ5nwZsYGCA5ORksYVmSzk5OeHixYsSS9PVq1exZcsWsaMj2DRgRhawmi7TZlpaWpgyZYrI5IjWkGSBe/ToUSxbtgwaGhoSi5NhJI3VdKVI3mu68obVdBlZwGq6DMMwHYgNGZMiFRWVZzweb4C009FZqKioPJN2GhiGNS/IMB6P5wvAC8BXAE4B+A+AbxS9TUJVVfXpmzdv2H9GEqaiovKssrKy7b2ejESwQldG8RoWL7gL4ByAhQD8iOiMdFPVMVhb94fB2rRlA2vTlV3TAQwEMBtAOAAvHo/3uXSTxDBMe7E2Xdm1A4AGgOcAdAAkADgv1RQxDNNurHlBRvF4vBEACoioWNpp6WiseeHDYM0LsoEVuozMYYXuh8EKXdkg1TZdVVXVpzwej9gh2UNVVfXp+799+ZOfnw89PT1u3Yjq6mqYmZnht99+Q05ODlRUVCAQCFBZWYn6+nqMGTMGAoEAI0aMgL+/v9DC7TExMTAzM4OZmRkmTZrEnW/cgqhxLeEXL14A6PitgF69eoWpU6fCyMgIY8eORW5urthwTaWXkWHSXG0HEtiuhhEFOV9Nq7l8ERYWRjNnziQiog0bNtBnn31GRETZ2dncqmqNSkpKiIiovr6ePv30Uzp8+DARET148IBMTU3p2bNnRET09OlT7p7mVk5rbgUzcerr69+7LVFTgoKCKCQkhIiIIiIiyNvbW2y45tL7LnnPF4pysNELjFxZvnw5cnNz8d133+HHH3/Et99+22TYxrV4a2pq8ObNG24LoR9++AHLli1D//79AQADBkh2SHBOTg5CQkJgbGyM8+fb1vcZExMDX19fAMCcOXNw4cKFxv+QGDnHRi8wckVJSQk7duyAvb09Dh48CHV19WbD29vbIyMjA1OnToWXlxeAhq2A6uvr4eDggDdv3uD//b//h7lz5wJoaPecNm0aiAienp4ICgpqUboqKipw+vRpHDhwACUlJZg3bx5+//13aGlpAQBOnTqFTZs2ib03NTVV5Fx+fj63OLuysjJ69eqF4uJi9OvXTyhcW9PLSA8rdBm5c/78eWhrayM9Pf29YZOSklBRUQEvLy/Ex8fj448/Rm1tLe7evYvLly+jpKQEdnZ2sLGxwbBhw5CYmAhdXV28evUKM2bMgK6uLubNm/fe5wwcOBDDhw/Hvn37uHWQ3+bh4QEPD482vW9z2ppeRnoUvnkhPDwckZGRzYbJz8/HjBkzJPK8o0ePwsjICHw+H9u3bxcbpqamBvPmzQOfz4dAIEBaWppEnt0ZZGZm4siRI0hJSUF0dHSLCt4ePXrAzc0NsbGxABq2AnJ1dYWysjL69++PcePGcT+Dxk0v+/bti7lz5yI5OblF6YqOjoaRkRFmzZqFoKAgZGRkCF0/deqU2E0/BQKB2Ph0dHS4DTerqqrw+vVrsUtWtjW9jBRJs0EZCtaR9vLlSzIwMKDnz59TRUUFmZiYUGZmpki48PBw8vX1JSKi+Ph4srOzk2g6IOcdJs3li48++ohOnTpFREQxMTFkb29P9fX1Ih1pRUVFVFRURERE1dXVNGPGDNq1axcREV26dIlmzZpF9fX1VFZWRsOHD6e7d+9SWVkZ1/lWVVVFrq6uFB4ezsXZko60kpIS2rt3L9nb25O1tTX99ttvzYZvyurVq4U60jw9PUXCvC+975L3fKEoh3QfLsFCNzIykvh8PllbW9OSJUto4cKFRET01Vdf0TfffENEDb+wq1atotGjR9OQIUPozJkzRCS+57stoqKiyM/Pj/scHBzMPfttTk5O9Ouvv3KfhwwZ0uIe6JaQ91+upvJFZGQkubi4CJ1zcXGhH374QeRneO/ePbK0tKSRI0eSqakp/eMf/6Camhru+qpVq8jExIRMTU1p586dRET08OFDsrCw4O75/PPPqba2lruntaMXsrKyKC0trcXh31ZcXExOTk7E5/NpzJgxlJOTQ0REeXl5NHXq1Bal913yni8U5VCINt2CggKsW7cOt2/fhrq6OpycnKCnpyc2bHl5OZKTk5GcnIxFixZh+vTpzcbt6OiIoqIikfP+/v7w9/cXOvfkyROh5+rr6+P27dsi974bTk9PD3l5ee3a9qYz8PHxgY+Pj9C5n3/+GUDDiIG3DR8+XOx332jr1q3YunWr0LmhQ4eK7dRqq2HDhrX5XnV1dbFbDr29M7Ok08t0DIUodK9fvw4HBweup9jT0xNJSUliw86aNQsAYGNjg+zs7PfGffnyZckllPlgunTpgrKyMggEAly7dg2qqqoSjf/o0aP4+uuvm2yDZZiWUohCtzWUlZUBNPySvj1DqSmtqenq6uoiLi6O+5ybm8sN+3k33OPHj2FgYAAAePz4sdhwTMvp6enhyZMnHyz+uXPncsPKGKY9FGL0gq2tLRITE1FUVIS6ujqcPHlSYnFfvnwZqampIse7BS7QsLPtlStXUFhYiMrKSpw4cQLu7u4i4dzd3bkRFQkJCejfvz9rWvhAZHH0yqVLl2BpaYmuXbvi+PHjQteioqJgbm4OgUCA8ePH48GDBwCAf/7zn9xoB1NTU3Tp0gXFxZ1uLSTFIM0GZUiwI23//v3E5/PJxsaGfH19KSAggIhEO9KuXbvG3aOsrExEkutIIyI6dOgQGRoa0tChQ+nbb7/lzq9bt45iY2OJqKGn2dvbmwwNDcnc3Jxu374tkWc3gpx3mEgyX3Sklo5eefDgAd25c4fmz59PUVFR3Pmqqirq168fPX/+nIiIdu7cSfPmzRO5//jx4+To6Njq9Ml7vlCUQ7oPl+AvV2lpKRER1dbW0syZM+nQoUMSi1veyPsvV1vyhTyNXmm0cOFCoUL3zZs3pKGhQQ8fPiQiok2bNtE///lPkftcXV3pwIEDrU6fvOcLRTkUpk1306ZNuHjxIiorK/HRRx/B29tb2kliOoi8jV5pirKyMvbs2QMLCwv07t0bGhoauHbtmlCY4uJi/PLLLzhy5EiL42Vki8IUulu2bMGWLVuknQxGChRl9EpNTQ127dqFW7duwdjYGOvXr0dQUBB27drFhTl58iScnZ3Rq1evDksXI1kKU+gyTEvIwuiVpqSmpoLH48HY2BgA4OXlJbKOwrFjx/DPf/6zxXEysocVuu9QUVHBmzdvOvSZqamp8PX1BRGhtrYWK1as4H6hly1bht9//x1Aw6IqkZGR0NHR6dD0yTpbW1usXLkSRUVFUFdXx8mTJyU2BK81NV0nJycEBQWhsLAQampqOHHiBKKjo1t8v66uLu7du4eCggJoa2sjLi4OJiYm3PXc3Fzcu3cPTk5OrXoHRrawQlcGGBsb48aNG+jWrRtKS0sxcuRITJ8+HXp6etiyZQu3LmxYWBjWr1+PH3/8Ucopli06OjoICQmBnZ0d1NXVYWZmJpU/v9XV1bFx40bY2dmBiODv74/hw4cDANavXw9ra2u4urri6tWrmDdvHl6+fImff/4ZgYGBePLkCbS1tfH1119j8uTJ6NatG7S0tBAREcHFHxUVhVmzZqFbt24d/m6M5Eh1j7T37YVVXl4Ob29v5OTkoL6+HosXL0ZAQAAiIyOxZ88eVFdXY8CAATh8+DD69++P4OBgZGdn4++//0Z2djZWrVoFAIiMjER1dTViYmJgaGiI4OBgPHjwAI8ePUJhYSF8fX3xr3/9C4BwTffkyZMIDQ1FdXU1DA0NERERgd69e2Pt2rWIiYlB165dYW5uLtFOjcLCQlhZWSEpKUmkM+jrr79GTk4O9u3b12wc8r4XVlv2SCsrK4Oamhrq6urg6ekJNzc3zJ8//wOlUD7Je75QGNIcOoH3DA06ffo0LVmyhPvcuPVJ4+pRRES7d++mL774gogahgfZ2trSmzdv6OnTp9SrVy/asWMHERFt376dVqxYwYUzMTGhsrIyKi0tJRMTE0pJSSGi/43dzczMJGdnZ6qqqiIios2bN9O6devoxYsXZGJiQnV1dUJpeltVVRVZWFiIPRrH6r7rzz//JDMzM1JRUaGwsDChaytXriQdHR2hLWaaAzkfGvS+fCHO6tWrSSAQkLGxMS1evFhocRumgbznC0U5pPvw9/xy/fXXXzRkyBD64osvKC4ujurr64mIKDExkcaPH09mZmZkZGTErfz01VdfUXBwMHe/np4etzrTlStXaPr06Vy4NWvWcOHWrFlD33//PRH9r9DduXMnaWtrc4WliYkJLViwgGpra8nS0pIbY1leXt7sO7RWbm4uWVlZCe3bRdSw39ZXX31F69evf28c8v7L1ZZCl3k/ec8XinLI9DRgPp+P27dvw9raGjt27MDixYsBAPPnz0doaCjS09Oxe/duoY6vxt5poGFrl8bPSkpKLeqtbkREmDNnDjftNyMjAwcPHkSXLl2QnJwMb29vJCUlwcbGRiTe6urqJhes/umnn5p9rp6eHkxNTZGYmCh0nsfjYf78+Th9+nSL34FhGNkj0x1peXl50NDQgJeXF4yNjeHn5wcAeP36NQYNGgQieu+8+qbExsbiyy+/BBEhNjYWhw8fFrru6OiI6dOn4/PPP4eOjg7Ky8vx5MkT6OjooKKiAk5OTpgwYQL09fVRVlaGvn37cvd27969VUvu5eTkQEdHB927d0dRURGSkpKwevVqAMD9+/e5JQJjYmKEerOZjiONUS0AkJGRgSVLlnBbq1+8eBF6enqYOHEiXr58CQDc3ml//PFHh6ePaT2ZLnTv3LmD1atXQ0lJCTwej5v8sGXLFtjb20NTUxOOjo7Iz89vddxWVlZwdHTkOtKsrKyErpuYmGDbtm1wcXHharIbNmxAz549MXPmTFRWVqK+vh6BgYFCBW5bXL9+HRs3bkSXLl0AAP/6179gZmYGAFi8eDFevHgBHo+HoUOH4j//+U+7nsXIj7q6OsyePRv79+/H6NGjUVpaiq5dG35lExISuHBLly7ltu1hZJ9Mj174UIKDg6GioqKwO6fKey81G9XS4Pz584iIiGh21byamhro6Ojg5s2b3FKhTZH3fKEoZLpNl2HEuXjxInR0dHDnzh3cvXsXCxYsAAC4urrixo0bSE1NhZubG7799lvunszMTFy8eBE3btzAmjVrUFdXh1u3bsHHxwfff/89F+727duIi4vDH3/8gSNHjoisnZCVlYWIiAgkJibijz/+wKhRoxAaGori4mLExMTg7t27uHPnjtDU3UatbevPysqCsrIypk2bBktLSwQFBaG+vl7kuzA2Nn5vgcvIDpluXvhQgoODpZ0Eph3Mzc0RGBiIwMBAODs7Y/LkyQCAe/fuYe3atSguLkZVVRWGDh3K3TNt2jQoKytjwIAB6Nu3L9zc3AAAAoEA8fHxXDh3d3f07NmT+3diYqJQ01NcXBzS0tJga2sLoKEgtbGxQZ8+faCiogI/Pz84OzvD1dVVJN2tbeuvra1FQkICbt26BU1NTXh4eODAgQNc3wbQsH4v23JdvrCaLiN3OsuoFj09PYwbNw7a2tro1q0b3N3dkZKSwl0vKyvDhQsXMHv27Bann5E+hSh0fXx8RFbg7ygGBgYwMzPjhngtW7YMFhYWsLCwgJOTE9fJl5qaCktLSwgEApiZmSE8PLxF8YeGhoLP58PIyAjHjh3jznt6ekJDQ0Nq7y1NeXl5UFZWhpeXFzZs2IBbt24BkNyoloqKCpSXlyM2NhYODg5C1x0dHREdHc39XMvLy5GVlYXS0lK8fPkSTk5O2LZtG4qKilBWViZ0b2NNV9whrmbs7OyMP//8E6WlpSAixMfHY8SIEdz1//73vxg/fjw0NDTa9K6MdHTK5gVJu3z5MrfdTlNrJTS3vkJTsrKycODAAaSnp6O0tBQ2NjaYNm0a+vbtixMnTojsjNtZdJZRLX369MG6detgZ2cHABgzZgwWLVrEXT969KhQUwMjJ6Q5MwNiZh59+eWXtG3bNu7zDz/8QP7+/kREtGLFCrK2tqYRI0bQ0qVLuRlqb6/AP3jwYCooKCAi0R0BwsLCyMbGhszNzWnRokUSmSr69vPetWnTJvrss89Ezj9//px0dXUpNze32bi/+eYb2rBhA/fZx8dHaKeBd3ceaAQ5n3kkLl90hLd3mVBE8p4vFOWQueYFb29vREVFcZ+joqIwZ84cAA0dYDdv3kR6ejqKi4tx9uzZFscbHx+PlJQUJCcnIy0tDUpKSjh06JBIuLCwMLFtbtOmTWvxswICAjBo0CAcO3YMX3/9NXc+IyMDI0eOhL6+PlatWtVsLRcQvxNBXl5ei9PBMIzskbnmBVNTU9TV1eH+/fvo1asXsrOzMW7cOABAdHQ0wsPDUVNTg6KiIggEAri4uLQo3nPnzuHq1avcn4uVlZXQ1NQUCRcQEICAgIB2vUNYWBh27NiBkJAQ7N69GyEhIdy7paen4/Hjx3B3d8fs2bMxYMCAdj2LkRw2qoXpCDJX6AL/q+326dMHs2fPBo/HQ3Z2NjZv3oybN29CU1MTa9euFTsts2vXrtxYxrevExECAwOxYsWKZp8dFhYmtIZpIx0dHZw7d67F79C4VoKbmxtX6DZ6e30FDw+PJuPQ1dXF48ePuc+5ublsAWuGkXMy17wANGxTcvz4caGmhdLSUvTo0QPq6uooKSnBqVOnxN47ZMgQbljN22GmTp2KiIgIlJSUAGiYr56TkyNyf0BAgNje5ZYWuPfv3+f+/fZaCTk5OaiurgYAbn2FxgWud+3aJXYwvZubG06cOIHKyko8f/4cV65cgbOzc4vS0dnJ0oiWiRMncs1U+vr6sLS0bFE8ISEhGDZsGExMTLiZcQAb0SLvZLKmO3jwYGhoaKCkpAQWFhYAGgbE29nZYfjw4dDW1oa9vb3Ye0NCQuDr64uQkBChAsrR0RGLFi3ihgB169YNO3fulPhMnqbWSmhufYXMzEyMHTtWJC4TExMsWLAAZmZm4PF42Lx5c7t7xJmO8faIlrask3Do0CGkp6cjIyMDXbt2xbNnzwCwES0KQZq9eFCAdVObG73QUtOnT+cWS2+NzjJ6QVFGtFRXV5OmpiZlZ2e/Nw5bW1u6e/euyPm2jmghkv98oSiHTDYvyBMtLS1MmTJFZP3b1jhz5gy6d+/eqns8PT3xyy+/QFVVtc3PlReKMKIFaN06CX/99RdiY2NhY2ODSZMmcWtAsBEt8k8mmxfkyc2bN6Xy3BMnTkjludKgCCNagNatk1BdXY3a2lrcvHkTSUlJ8PDwwKNHj9qdBkb6WKHLyAV5H9HSuE7C7t27WxReT08Ps2bNAgDY29ujrq4OhYWFbESLAmDNC4xckOcRLUDT6yQ0jmB516effoorV64AaFg9rb6+HpqammxEiwKQak1XRUXlGY/HY7MDJExFReWZtNMgafI8ogUQv05CUVFRY8ehiFWrVmH+/PnYu3cvunfvjiNHjoDH47ERLQpAqjtHMIw40tpRRFIMDAyQnJzMDRlrypkzZ/Do0SOJtBc38vHxgbOzM7y8vESusZ0jZANrXmAYCWvpiBYXFxeJFridaUSLPGM1XUbmyHtNV1axmq5sYDVdhmGYDsSGjDEyh3WwfhiK2MEqj1jzAsPIMR6PpwbgAIBBAD4F8B8Al4hojzTTxTSNFbpSoKqq+vTNmzesJiclKioqzyorK5sfWiBHeDyeEoC1ABYD2ABgFYDhRFQn1YQxYrFCVwpYR5F0KVqHEo/HGwpAAKA3gG0ASgD8k4hipJkuRjxW6EoBK3SlSwELXVsA6wGMAVANQBPAMyJqfj8oRipYoSsFrNCVLkUrdBvxeDweACMAkwE4EtFMKSeJEYMVulLACl3pUtRCl5EPbJwuwzBMB2KFrgzIz8+Hnp4e8vPzATSspWpmZobffvsNOTk5UFFRgUAgQGVlJYD/7cHVuJj2ixcvAACXLl2CpaUlunbtKrJPlre3N/r37y+yqtXRo0fB5/M7bKWqpUuXwtjYGObm5vj000/x8uVL7lpTe3+lpaVBIBCAz+dj3rx5qKmpEYn37e9JIBBgxowZHfI+HU1VVfUpj8cjdrT+UFVVfSrtnx8A6W7X01kPiNmmKCwsjGbOnElERBs2bKDPPvuMiES3lyFqejuYBw8e0J07d2j+/PkiW7YkJCRQSkqKSFyN15ycnETON6W+vp5evnzZ4vBvO3fuHNXW1hIR0apVq+iLL74gIqLMzEwaMWIEVVRU0LNnz0hfX597xpgxY+iXX34hIqIFCxbQ3r17ReIV9z01BXK8bY24vMO0jKz83FlNV0YsX74cubm5+O677/Djjz/i22+/bXUchoaGGDlyJJSURH+sEyZMEFnLtbVycnIQEhICY2NjnD9/vk1xTJ06lducc/To0dyC3DExMfD09ISqqir69++PSZMm4cKFC3j69CkKCwsxfvx4AICfnx+io6Pb9R4MI01sGrCMUFJSwo4dO2Bvb4+DBw9CXV29ybA8Hg/Tpk0DEcHT0xNBQUEfLF0VFRU4ffo0Dhw4gJKSEsybNw+///47tLS0ADQsCr5p0yax96ampjYZLxFh37598PT0BNCw95e1tTV3vXHvrydPngjtntvcnmC5ubmwsrKCiooK/vWvf7V42x6G6Uis0JUh58+fh7a2NtLT05sNl5iYCF1dXbx69QozZsyArq5ui/feaq2BAwdi+PDh2LdvH7d4+Ns8PDzg4eHR6nhDQkLQvXt3LFy4UBLJhLa2NnJzc6GpqYmsrCx8/PHHMDU1xdChQyUSvyILDw+HsrIyfH19mwyTn5+P5cuXIyam/fMtjh49iuDgYBARli5dii+++EIkTE1NDXx9fZGcnAw1NTUcPHhQbP6TR6x5QUZkZmbiyJEjSElJQXR0dLMFb2PNr2/fvpg7dy6Sk5M/WLqio6NhZGSEWbNmISgoCBkZGULXT506JXanXIFA0GSce/fuxaVLlxAVFYWGoaUQu/fXoEGDoKuriydPnoicf5eysjK3qaSxsTHGjx/P7aDLNM/f37/ZAhdo2A9OEgXuq1ev8OWXXyIpKQnp6enYv38/srKyRMJFRESge/fuePDgAb777jssXbq03c+WGdJuVO6MB8R0hnz00Ud06tQpIiKKiYkhe3t7qq+vF+kgKisro5KSEiIiqqqqIldXVwoPDxeKa+HChSIdaURNdza1pCOtpKSE9u7dS/b29mRtbU2//fZbs+GbcurUKTIzM6MXL14Inc/IyBDqSNPT0+M60kaPHi3UkbZnzx6ReJ8/f041NTVERPT06VMaMmQIZWRkiE0DZKRDpS2HuLzTUpGRkcTn88na2pqWLFlCCxcuJCKir776ir755hsiasiHq1atotGjR9OQIUPozJkzRNS6jsrmREVFkZ+fH/c5ODiYe/bbnJyc6Ndff+U+DxkyRGzncWvIys+d1XRlwIEDB9CrVy/MnNkwgcjd3R0aGhr48ccfRcI+e/YM48ePh7m5OSwtLcHn8/HZZ58BAK5evQpdXV2cPHkSy5cvF2oLdXV1hZ2dHR4+fAhdXV38+9//blUae/fujcWLF+P333/H0aNH0atXrza9q7+/P16/fo1JkyZBIBBwNay39/6yt7cX2vtrz549WLlyJfh8Pmpqari9xn766SesX78eQEOTi4WFBSwsLDBlyhSsX78eJiYmbUqjIiooKMC6deuQlJSEa9eu4a+//moybHl5OZKTk3Hs2LEW9Rc4OjqK/UsnPDxcJOyTJ0+gp/e/2clNtdG/G05PT6/Jtnx5w9p0ZYCPjw98fHyEzv38888AILI77dChQ5vsoJowYYLQn+Jv++mnn9qbTM6wYcPafG9hYWGT11atWoVVq1aJnLe0tERaWprIeVdXV7i6ugJo2D33008/bXO6FN3169fh4ODAdYB6enoiKSlJbNjGrd9tbGyQnZ393rgvX74suYR2AqymK+O6dOmCsrIyockRknT06FEsW7as3cPJGMWhrKwMoCHv1dbWvjd8a2q6TbXdvy/c48ePxYaTS9Ju3+iMBz7wAPc9e/ZQREREs2Hy8vLI3d1dIs87cuQI8fl8MjQ0pNDQULFhqqurae7cuWRoaEgWFhaUmppKRET5+fk0atQosrCwIBMTE1q/fj13j7+/Pw0bNoxGjhxJM2bMoOLiYomkFzLStteWo615Jy8vj3R1damwsJBqa2vJ0dGxyTbda9eucfcpKysTkeTadIuLi2nw4MH0/PlzqqioIBMTE7p3755IuD179pCvry8REcXHx9Po0aPb/WxZ+blLPQGd8fjQhW5HevnyJRkYGAj9EmVmZoqECw8PF/olsrOzI6KGwriiooL7t62tLSUmJhJR07PX2ktWfvnacrQn7+zfv5/4fD7Z2NiQr68vBQQEEFHHFrpERIcOHSJDQ0MaOnQoffvtt9z5devWUWxsLBE1dBJ7e3uToaEhmZub0+3bt9v9XFn5uUs9AZ3xkFShq2i90WVlZSQQCMSOjDh9+jTNnj273eklkp1fvrYc7ck7paWlRERUW1tLM2fOpEOHDrU5LnkkKz931qYrpxSpN/rVq1ewsLBA//794ejoiLFjxwrdS9Qwe23q1KnvTTvTtE2bNsHS0hIjRoxAv3794O3tLe0kdUps9IKcUqTe6L59+yItLQ3FxcVwc3PD3bt3YWZmxl2X9Oy1zmrLli3YsmWLtJPR6bFCtxNoS290UVGRyHl/f3/4+/sLndPV1UVcXBz3+X290QYGBgDE90ZraGhgwoQJuHDhAlfoNs5eu3z5Mjd7jWHkGWtekFO2trZITExEUVER6urqcPLkSYnFffnyZaSmpooc7xa4AODk5IQrV66gsLAQlZWVOHHiBNzd3UXCubu7IzIyEgCQkJCA/v37Y+DAgcjPz0d5eTmAhmaQuLg4blLD6dOnsWvXLpw5cwY9evSQ2PsxkqOioiKV52ZkZMDBwQGmpqYwNTUVGl4m61hNV07p6OggJCQEdnZ2UFdXh5mZWZtnibWHuro6Nm7cCDs7OxAR/P39uYXS169fD2tra7i6usLPzw+//vor+Hw+evbsiQMHDgAA/vrrL6xcuRI8Hg91dXWYM2cOpk+fDqChZt2jRw9MmjQJQMMkicaCm+m86urqMHv2bOzfvx+jR49GaWkpunaVn6KM7ZEmBZLaI62srAxqamqoq6uDp6cn3NzcMH/+fAmkULHJ8x5pzeWd8vJyeHt7IycnB/X19Vi8eDECAgIQGRmJPXv2oLq6GgMGDMDhw4fRv39/BAcHIzs7G3///Teys7O52YCRkZGorq5GTEwMDA0NERwcjAcPHuDRo0coLCyEr68v/vWvfwFoqOm+efMGAHDy5EmEhoaiuroahoaGiIiIQO/evbF27VrExMSga9euMDc3x5EjR9r1HZw/fx4RERGt/utOVn7urHlBjrHeaOZtFy9ehI6ODu7cuYO7d+9iwYIFABqmS9+4cQOpqalwc3MTWiA/MzMTFy9exI0bN7BmzRrU1dXh1q1b8PHxwffff8+Fu337NuLi4vDHH3/gyJEjIiu4ZWVlISIiAomJifjjjz8watQohIaGori4GDExMbh79y7u3LmDXbt2iaS7urq6yZXqxE1fz8rKgrKyMqZNmwZLS0sEBQWhvr5eQt/ihyc/dXJGBOuNZt5mbm6OwMBABAYGwtnZGZMnTwYA3Lt3D2vXrkVxcTGqqqqE1hieNm0alJWVMWDAAPTt2xdubm4AAIFAgPj4eC6cu7s7evbsyf07MTERVlZW3PW4uDikpaXB1tYWQENBamNjgz59+kBFRQV+fn5wdnbm1sp4W/fu3Ztd8P5dtbW1SEhIwK1bt6CpqQkPDw8cOHCAWwhJ1rGaLsMoCD6fj9u3b8Pa2ho7duzA4sWLAQDz589HaGgo0tPTsXv3bq45APjfyBagYfeSxs9KSkotGunSiIgwZ84crtM1IyMDBw8eRJcuXZCcnAxvb28kJSXBxsZGJN7W1nT19PQwbtw4aGtro1u3bnB3d0dKSkqrvitpYoUu0yRZ65netm0bDA0NwePx8PSpbGzsKkvy8vKgrKwMLy8vbNiwAbdu3QIAvH79GoMGDQIRtbkjMjY2FhUVFSgvL0dsbCwcHByErjs6OiI6Oprb0bq8vBxZWVkoLS3Fy5cv4eTkhG3btqGoqAhlZWVC9zbWdMUd4mrGzs7O+PPPP1FaWgoiQnx8PEaMGNGm95IG1rzAyJTmeqYnTpyI2bNn46OPPpJyKmXTnTt3sHr1aigpKYHH43FNT1u2bIG9vT00NTXh6OjIFYytYWVlBUdHR64j7e2mBaBhPeRt27bBxcWFq8lu2LABPXv2xMyZM1FZWYn6+noEBgZy6yS3VZ8+fbBu3TrY2dkBAMaMGYNFixa1K86OxEYvSEFbRi+wnun/MTAwQHJyMgYOHNimZ8hKL3ZbSGrkS2sEBwdDRUXlg26A2hFk5efOmhfkBOuZZhjFwJoX5ATrmZaPnmlFFBwcLO0kKBRW05UTrGeaYRQDq+nKiby8PGhoaMDLywvGxsZczU9SPdNffvkliAixsbE4fPiw0HVHR0dMnz4dn3/+OXR0dFBeXo4nT55AR0cHFRUVcHJywoQJE6Cvr4+ysjKhjpLW1nSdnZ2xceNGlJaWQk1NDfHx8VyHCcMoAlbTlRN37tzB6NGjIRAI4OfnJ9IzbWNjA319/TbF3dgzLRAIMHfu3GZ7ps3NzWFnZ4d79+6hpKQErq6uMDc3x6hRoyTeMz1y5EgoKytzPdPffPMNdHV18eTJE1hZWXFLVjKt4+Pjg+PHj0vl2QYGBjAzM0NiYiJ3LiQkBMOGDYOJiQnXiduc3NxcjB07FkZGRpg6dSpKSkoANCykZGpqyq39IbOkvYp6ZzwgQ9v1vL3LRGcBGdlBoC2HJPLOwoULKSoqqt3xtMXgwYOFdgw5ePAgzZw5k2pqaoiI6OnTp++Nw8vLiw4ePEhEROvXr6c1a9Zw15rbEUVWfu6spsswcmzdunUIDQ3lPu/btw9Lly4FAKxcuRI2NjYwMzPDsmXLGgttIQYGBtxEk5ycHKFa4s6dO2FrawsLCwssXry4Vf0ALbV7926EhIRwY7EHDBjQbHgiwsWLF+Hl5QUA8PPzQ3R0tMTT9SGxQreTCw4Olvvxl52Zt7c3oqKiuM9RUVGYM2cOgIaf7c2bN5Geno7i4mKcPXu2xfHGx8cjJSUFycnJSEtLg5KSEg4dOiQSLiwsTGwn6bRp01r0nL/++guxsbGwsbHBpEmTRIYrvuvFixfo3bs3unfvDqBhcfyCgoIWv5csYB1pDCPHTE1NUVdXh/v376NXr17Izs7GuHHjAADR0dEIDw9HTU0NioqKIBAI4OLi0qJ4z507h6tXr3Lt+5WVldDU1BQJFxAQgICAgDanv7q6GrW1tbh58yaSkpLg4eGBR48etTk+ecBqugpEljpI2rpOQlOdKqGhoeDz+TAyMsKxY8e4856entDQ0JDae8uCxtruiRMnMHv2bPB4PGRnZ2Pz5s24ePEi7ty5A19fX6HhhI26du3KTT55+zoRITAwkBsmmJWVhU2bNonc396arp6eHtcham9vj7q6OhQWFjYZvl+/fnj9+jWqq6sBNGx4qq2t3aJnyQpW6DISc/nyZW4hlIkTJyI+Ph6DBw9u8f2HDh1Ceno6MjIycO/ePfzjH/8A0DBL7cCBA0hPT8fvv/+ONWvW4NWrVwCAEydOiJ2U0Zl4eXnh+PHjQk0LpaWl6NGjB9TV1VFSUoJTp06JvXfIkCHcOOi3w0ydOhURERHcyIDi4mLk5OSI3B8QECB2oZpz5861KO2ffvoprly5AqBhok99fT1XoxY3CoHH42HKlCncf7IRERFit4eSZazQlVHy3kFibW3dqgIXaLpTJSYmBp6enlBVVUX//v0xadIkXLhwQeJplleDBw+GhoYGysvLYWFhAQDc0L7hw4fjk08+gb29vdh7Q0JCEBgYCGtra6GarqOjIxYtWgQHBweYm5vj448/btNCOe+zatUqXLp0CSNHjsS8efNw5MgR8Hg8FBUVic3XALB161bs2bMHRkZGuH79uvz1SUh7+ERnPNCCYT9//vknWVlZcZ8nTpxIv/76KxERFRUVERFRfX09eXp60s8//0xEwkOB3h6a8/YwmitXrtDChQuprq6OiIiWLFlC+/fvF3n+jh07yMLCQuSYOnWq2PS+OxTofefFUVdXp6+//pqsra1p4sSJlJKSQkREy5cvp8jISC7c+vXrKTQ0lPvc2iFQkJGhQ205WpJ3ZFlL88PPP/9MO3bsaHX88jBkjHWkySh57yBpi87YqdLZaGlpYcqUKdi9e7fImrxva2l+fltCQgICAgKgpaXVniR+cKzQlWGNHSR9+vQR6SC5efMmNDU1sXbt2jZ1kKxYsaLZZ4eFhSEiIkLkvI6OTovb61qrqU4VXV1doS22c3Nz4eTk9EHSwHxYN2/e/GBxT5w4Eenp6R8sfklhbboyTJ47SJrT1DTNpjpV3NzccOLECVRWVuL58+e4cuUKnJ2d250OhpEGVujKMHnuIGlqnYTmOkia6lQxMTHBggULYGZmBnt7e2zevLndazzIKxUVlWc8Hg/saP2hoqLyTNo/P4DtHCEV0lj9/0Nr6W4OZ86cwaNHjyTaXuzj4wNnZ2duauj7yMoOAkznxGq6jEQ0dpC8vXqUOC4uLhItcD09PfHLL79AVVVVYnEyzIfEarpSoIg1XXnCarqMNLGaLsMwTAdihS7DMEwHYuN0peD/eqCbXziU+WBkpReb6ZxYm64M4/F4IQAGAsgBsALALCJKkmqiZASPxxsEIBoN380lAHOIaLJUE8UwLcAKXRnF4/F6oKFAuQmgP4AZAAqIqE6a6ZIVPB6PB0AVwB4A5gAGAHAhouZXwWYYKWNturLr/wPQG4A2gOcA/gCwWaopki2fAHgGYDCAIgAaALZKNUUM0wKspiujeDzeXQBqaPgT+hqAa0T0RLqpki08Hq8vgNEA7ABMBzAcQG82Ho+RZazQZRiG6UCseYFhGKYDSXXImKqq6tM3b96woVMSpqKi8qyysrL5RRDkCMsnbadoeUERSLV5gU2H/TAUbZoryydtp2h5QRGw5gWGYZgOxApdhmGYDsQKXYZhmA6k8IVueHg4IiMjmw2Tn5+PGTNmSOR5R48ehZGREfh8PrZv3y42TE1NDebNmwc+nw+BQIC0tDSJPJtpOZYvGKmR5lbEkPPtpN/18uVLMjAwoOfPn1NFRQWZmJhQZmamSLjw8HDy9fUlIqL4+Hiys7OTaDogI1tNS+qQ93wizXyhaHlBEQ6FqekeOHAARkZGsLGxgb+/P3x8fAAAwcHB2LJlCwBgwoQJWL16NcaMGYOhQ4fi7NmzAICcnJwmN0tsjQsXLmDSpEnQ0tKCqqoqPD09ERMTIxIuJiYGvr6+ABp2MH369CmePn3a7uczoli+YGSNQiztWFBQgHXr1uH27dtQV1eHk5MT9PT0xIYtLy9HcnIykpOTsWjRIkyfPr3ZuB0dHVFUVCRy3t/fH/7+/kLnnjx5IvRcfX193L4tuv7Ku+H09PSQl5f33v3FmNZh+YKRRQpR6F6/fh0ODg7Q0tIC0LBvVlKS+BUQG3eltbGxQXZ29nvjvnz5suQSynQoli8YWaQQhW5rKCsrAwC6dOmC2tra94ZvTY1GV1cXcXFx3Ofc3FwMGjRI5F5dXV08fvwYBgYGAIDHjx+LDcd0HJYvmI6iEIWura0tVq5ciaKiIqirq+PkyZMSy6ytqdE4OTkhKCgIhYWFUFNTw4kTJxAdHS0Szt3dHZGRkXBwcEBCQgL69+/P/oT8AFi+YGSRQhS6Ojo6CAkJgZ2dHdTV1WFmZoZevXp1eDrU1dWxceNG2NnZgYjg7+/PdcSsX78e1tbWcHV1hZ+fH3799Vfw+Xz07NkTBw4c6PC0dgYsXzCySGHWXigrK4Oamhrq6urg6ekJNzc3zJ8/XyJxyxtFm2/fnnzS2fOFouUFRaAwQ8Y2bdoES0tLjBgxAv369YO3t7e0k8TIAJYvGFmjMDVd5n8UrXbD8knbKVpeUAQKU9OVFBUVFak8NyMjAw4ODjA1NYWpqSkeP34MoKGne+zYsTAyMsLUqVNRUlIilfQx/yONPJKXl4ePPvoIPXv2FBkdwcgXVujKgLq6OsyePRuhoaHIyMjA9evXoampCQBYvXo1lixZgr/++gu2trbYupXtvdgZqampYfPmzU2u28DID5kudMvLy+Hq6gpzc3OYmZkhLCwMABAZGQlbW1sIBAI4OTnh+fPnABqmdi5cuBATJkzA4MGDsXv3buzevRvW1tYwNzfHw4cPuXDz5s2Dvb09jIyMsHmz+E12T548idGjR8PS0hIeHh54/fo1AGDt2rUwNTWFubk55s2b1+73vHTpEkxMTDB69GgAQK9evaCqqgoiwsWLF+Hl5QUA8PPzEzvUqDPrLHmkT58+GDt2rNT+EmMkSJoLP+A9C5mcPn2alixZwn1++fIlEREVFRVx53bv3k1ffPEFERF99dVXZGtrS2/evKGnT59Sr169aMeOHUREtH37dlqxYgUXzsTEhMrKyqi0tJRMTEwoJSWFiIiUlZWJiCgzM5OcnZ2pqqqKiIg2b95M69atoxcvXpCJiQnV1dUJpeltVVVVZGFhIfaIjY0VCf/dd9/R3LlzaerUqSQQCGj16tVUV1dHhYWFNHjwYC5cbW0t9e7du9nvjIgUbpGT5vJJZ8kjjSIjI4Xe930ULS8owiHT43TNzc0RGBiIwMBAODs7Y/LkyQCAe/fuYe3atSguLkZVVRWGDh3K3TNt2jQoKytjwIAB6Nu3L9zc3AAAAoEA8fHxXDh3d3f07NmT+3diYiKsrKy463FxcUhLS4OtrS0AoLq6GjY2NujTpw9UVFTg5+cHZ2dnuLq6iqS7e/fuSE1NbfF71tbWIiEhAbdu3YKmpiY8PDxw4MABsXEzwjpLHmEUh0w3L/D5fNy+fRvW1tbYsWMHFi9eDACYP38+QkNDkZ6ejt27d+PNmzfcPY3TOQFASUmJ+6ykpNSi6Z2NiAhz5sxBamoqUlNTkZGRgYMHD6JLly5ITk6Gt7c3kpKSYGNjIxJvdXU1BAKB2OOnn34SeZaenh7GjRsHbW1tdOvWDe7u7khJSUG/fv3w+vVrVFdXA2hYEEVbW7vlX2An0FnyCKM4ZLqmm5eXBw0NDXh5ecHY2Bh+fn4AgNevX2PQoEEgovcuRN2U2NhYfPnllyAixMbG4vDhw0LXHR0dMX36dHz++efQ0dFBeXk5njx5Ah0dHVRUVMDJyQkTJkyAvr4+ysrK0LdvX+7e1tZinJ2dsXHjRpSWlkJNTQ3x8fGws7MDj8fDlClTcPz4cSxYsAARERFwd3dv0/sqqs6SRxjFIdOF7p07d7B69WooKSmBx+Nx659u2bIF9vb20NTUhKOjI/Lz81sdt5WVFRwdHVFYWAhfX1+hPxsBwMTEBNu2bYOLiwtXS9mwYQN69uyJmTNnorKyEvX19QgMDBT6ZWqLPn36YN26dbCzswMAjBkzBosWLQIAbN26FV5eXti4cSMMDQ1x/Pjxdj1L0XSWPFJVVQVDQ0NUVFSguroaZ86cwcmTJ7k8w8iPTjk5Ijg4GCoqKggKCurwZ3cERRsQL418oih5RNHygiKQ6TZdhmEYRdMpa7qKTtFqNyyftJ2i5QVFwGq6DMMwHYgVugzDMB1IIQpdHx8fqfXqGxgYwMzMDImJiQDatkBNTU0Nli9fjmHDhmH48OH4z3/+w1374osvwOfzYWJigitXrnDnHRwcoKamhuTkZMm/lAKSpTyybds2GBoagsfjtXi336byVUJCAkxNTSWyazHTMRSi0JW2y5cvw8HBAUDbFqj55ptv0K1bN9y/fx+ZmZnw8PAAAFy8eBFpaWm4f/8+/vvf/2Lx4sWoq6sDACQmJsLa2vrDvRQjUW/nkYkTJyI+Ph6DBw9u8f1N5auJEyfi3LlzHyTNzIchc4XuunXrEBoayn3et28fli5dCgBYuXIlbGxsYGZmhmXLlkFc54qBgQFXe8jJyRGqAezcuRO2trawsLDA4sWLWzX7qCWI2rZAzd69exESEsJ97t+/PwAgJiYGCxcuhJKSEoyNjaGvr4+bN29KNM3ySJ7zCABYW1u3qsBta75iZJPMFbre3t6IioriPkdFRWHOnDkAGsZO3rx5E+np6SguLsbZs2dbHG98fDxSUlKQnJyMtLQ0KCkp4dChQyLhwsLCxE7NnDZt2nuf8eLFC/Tu3Rvdu3cH0LC7a0FBQbP3vHr1CkSEzZs3Y9SoUXBxccGjR48ANEz71dPT48Lq6+sjLy+vxe+sqOQ5j7RFW/IVI7tkbkaaqakp6urqcP/+ffTq1QvZ2dkYN24cACA6Ohrh4eGoqalBUVERBAIBXFxcWhTvuXPncPXqVW5WUWVlJbdm7dsCAgIQEBAguRd6j9raWhQUFGDEiBHYunUrTpw4AR8fH/z6668dlgZ509nyCKNYZK7QBf5Xk+nTpw9mz54NHo+H7OxsbN68GTdv3oSmpibWrl0rtIhJo65du6K+vh4AhK4TEQIDA7FixYpmnx0WFoaIiAiR8zo6Ou9tO3t7gZru3bu3aIGafv36QVVVFbNmzQIAeHh44LPPPgPQUKNp3EECaOhMkdQW4vJOXvNIW7QlXzGyS+aaFwDAy8sLx48fF/qzsbS0FD169IC6ujpKSkpw6tQpsfcOGTIEKSkpACAUZurUqYiIiOB6fYuLi5GTkyNyf0BAALdq1NtHS36Z3l6gBoDQAjV5eXncsoPv3jNjxgxuZEJCQgJMTEwANCwneOjQIdTX1yMrKwt///03bGxs3puOzkBe88j7iBuF0Fy+YuSPTBa6gwcPhoaGBsrLy2FhYQGgYd1UOzs7DB8+HJ988gns7e3F3hsSEoLAwEBYW1sL1WIcHR2xaNEiODg4wNzcHB9//HGbFkF5n61bt2LPnj0wMjLC9evXubn7BQUF6NpV/B8WW7duxfbt22Fubo6vvvoK+/fvBwA4OTlhxIgRMDIygpubG/bu3YsuXbpIPM3ySJ7zyDfffANdXV08efIEVlZW3F85RUVFYjv+gKbzFSN/2DTgdjIwMEBycjIGDhzYbLhdu3ZBX19foguTT5gwAVu2bMGYMWOEziva1E95zyctzSNnzpzBo0ePWt1enJOTA2dnZ2RmZopcU7S8oAhksqYrT7S0tDBlyhRu4HtTVqxYIdEC18HBAY8ePeJ6tBnZ1dI84uLi0uoCNyEhAZ988gm0tLTak0SmA7GargJStNoNyydtp2h5QRGwmi7DMEwHkuqQMRUVlWc8Hm+ANNOgiFRUVJ5JOw2SxPJJ2ylaXlAEUm1eYBiG6WxY8wLDMEwHYoUuwzBMB2KFLsMwTAdihS7DMEwHYoUuwzBMB2KFLsMwTAdihS7DMEwHYoUuwzBMB2KFLsMwTAdihS7DMEwHYoUuwzBMB2KFLsMwTAf6/wHNm6ARraJKZQAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
@@ -346,17 +327,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 65,
    "id": "8ef9673d",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x407808e3a0>"
+       "<matplotlib.image.AxesImage at 0x406f4f60d0>"
       ]
      },
-     "execution_count": 45,
+     "execution_count": 65,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -381,17 +362,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 66,
    "id": "3cafd3ee",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.image.AxesImage at 0x40780f26a0>"
+       "<matplotlib.image.AxesImage at 0x406f541850>"
       ]
      },
-     "execution_count": 46,
+     "execution_count": 66,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -416,7 +397,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 67,
    "id": "4d4e509b",
    "metadata": {},
    "outputs": [
@@ -426,7 +407,7 @@
        "1"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 67,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -448,7 +429,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 68,
    "id": "cf325cd7",
    "metadata": {},
    "outputs": [
@@ -458,7 +439,7 @@
        "(138, 0, 0)"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 68,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -469,21 +450,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 69,
    "id": "96e8a4c1",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([1, 1, 0, 0, 1, 1, 1, 0, 1, 0, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 0,\n",
+       "array([1, 1, 0, 0, 1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0,\n",
        "       1, 0, 1, 1, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 0,\n",
-       "       0, 0, 1, 0, 0, 1, 1, 1, 0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1,\n",
+       "       0, 0, 1, 1, 0, 1, 1, 1, 1, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1,\n",
        "       0, 1, 1, 1, 0, 1, 0, 0, 1, 1, 1, 0, 0, 0, 1, 0, 1, 1, 1, 0, 0, 1,\n",
        "       0, 0, 0, 0, 0, 1, 1, 0, 1, 1, 0, 1])"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 69,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -495,7 +476,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 70,
    "id": "2c99e91c",
    "metadata": {},
    "outputs": [
@@ -503,11 +484,11 @@
      "data": {
       "text/plain": [
        "array([ True,  True,  True,  True,  True,  True,  True,  True,  True,\n",
-       "        True,  True,  True, False,  True,  True,  True,  True,  True,\n",
+       "        True,  True,  True,  True,  True,  True,  True,  True,  True,\n",
        "        True,  True,  True,  True,  True,  True,  True, False,  True,\n",
        "        True,  True,  True,  True,  True,  True,  True,  True,  True,\n",
        "        True,  True,  True,  True,  True,  True,  True,  True,  True,\n",
-       "        True,  True, False,  True,  True,  True,  True,  True,  True,\n",
+       "        True,  True,  True,  True,  True,  True,  True, False,  True,\n",
        "        True,  True,  True,  True,  True,  True,  True,  True,  True,\n",
        "        True,  True,  True,  True,  True,  True,  True,  True,  True,\n",
        "        True,  True,  True,  True,  True,  True,  True,  True,  True,\n",
@@ -516,7 +497,7 @@
        "        True])"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 70,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -528,17 +509,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 71,
    "id": "15b7f378",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([47])"
+       "array([], dtype=int64)"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 71,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -557,65 +538,54 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 72,
    "id": "b76e361b",
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "array([147])"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[]\n"
+     ]
     }
    ],
    "source": [
     "# display the false_custom(s)\n",
     "\n",
     "indices = false_customs + len(histograms)//2\n",
-    "indices"
+    "print(indices)\n",
+    "\n",
+    "if len(indices) > 0:\n",
+    "    file = files[\"filenames\"][indices[0]]\n",
+    "    Image.open(file)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "id": "4c852678",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAaQAAAGkCAIAAADxLsZiAAAF/ElEQVR4nO3XUcqbQABG0Vry6lqFLERwpwNuoA+Bvv5QUifmnrOB+WDwqssY4xfAt/s9ewDAFcQOSBA7IEHsgASxAxLEDkgQOyBB7IAEsQMSxA5IEDsgQeyABLEDEsQOSBA7IEHsgASxAxLEDkgQOyBB7IAEsQMSxA5IEDsgQeyABLEDEsQOSBA7IEHsgASxAxLEDkgQOyBB7IAEsQMSxA5IeFx20nnsl511mXV7zp7wTu7o87mjf+bLDkgQOyBB7IAEsQMSxA5IEDsgQeyABLEDEsQOSBA7IEHsgASxAxLEDkgQOyBB7IAEsQMSxA5IEDsgQeyABLEDEsQOSBA7IEHsgASxAxLEDkgQOyBB7IAEsQMSxA5IEDsgQeyABLEDEsQOSBA7IEHsgASxAxLEDkgQOyBB7IAEsQMSxA5IEDsgQeyABLEDEsQOSBA7IEHsgASxAxLEDkgQOyBB7IAEsQMSxA5IEDsgQeyABLEDEsQOSBA7IEHsgASxAxLEDkgQOyBB7IAEsQMSxA5IEDsgQeyABLEDEsQOSHjMHnBv57HPnsAP3BEvyxhj9oa7+sqnaN2esye8kzviL7+xQILYAQliBySIHZAgdkCC2AEJYgckiB2QIHZAgtgBCWIHJIgdkCB2QILYAQliBySIHZAgdkCC2AEJYgckiB2QIHZAgtgBCWIHJIgdkCB2QILYAQliBySIHZAgdkCC2AEJYgckiB2QIHZAgtgBCWIHJIgdkCB2QILYAQliBySIHZAgdkCC2AEJYgckiB2QIHZAgtgBCWIHJIgdkCB2QILYAQliBySIHZAgdkCC2AEJYgckiB2QIHZAgtgBCWIHJIgdkCB2QILYAQliBySIHZAgdkCC2AEJYgckiB2QsIwxrjnpPPZrDgLuZd2eF5zyuOCML3bNJV3mK19I7ogXv7FAgtgBCWIHJIgdkCB2QILYAQliBySIHZAgdkCC2AEJYgckiB2QIHZAgtgBCWIHJIgdkCB2QILYAQliBySIHZAgdkCC2AEJYgckiB2QIHZAgtgBCWIHJIgdkCB2QILYAQliBySIHZAgdkCC2AEJYgckiB2QIHZAgtgBCWIHJIgdkCB2QILYAQliBySIHZAgdkCC2AEJYgckiB2QIHZAgtgBCWIHJIgdkCB2QILYAQliBySIHZAgdkCC2AEJYgckiB2QIHZAgtgBCWIHJIgdkCB2QILYAQliBySIHZDwmD3g3s5jnz2BH7gjXpYxxuwNd+UpYop1e86ecEt+Y4EEsQMSxA5IEDsgQeyABLEDEsQOSBA7IEHsgASxAxLEDkgQOyBB7IAEsQMSxA5IEDsgQeyABLEDEsQOSBA7IEHsgASxAxLEDkgQOyBB7IAEsQMSxA5IEDsgQeyABLEDEsQOSBA7IEHsgASxAxLEDkgQOyBB7IAEsQMSxA5IEDsgQeyABLEDEsQOSBA7IEHsgASxAxLEDkgQOyBB7IAEsQMSxA5IEDsgQeyABLEDEsQOSBA7IEHsgASxAxLEDkgQOyBB7IAEsQMSxA5IEDsgQeyABLEDEsQOSBA7IEHsgIRljDF7A5/iPPbZE95v3Z6zJ/ARfNkBCWIHJIgdkCB2QILYAQliBySIHZAgdkCC2AEJYgckiB2QIHZAgtgBCWIHJIgdkCB2QILYAQliBySIHZAgdkCC2AEJYgckiB2QIHZAgtgBCWIHJIgdkCB2QILYAQliBySIHZAgdkCC2AEJYgckiB2QIHZAgtgBCWIHJIgdkCB2QILYAQliBySIHZAgdkCC2AEJYgckiB2QIHZAgtgBCWIHJIgdkCB2QILYAQliBySIHZAgdkCC2AEJYgckiB2QIHZAgtgBCWIHJIgdkCB2QILYAQliBySIHZAgdkCC2AEJyxhj9gaA/86XHZAgdkCC2AEJYgckiB2QIHZAgtgBCWIHJIgdkCB2QILYAQliBySIHZAgdkCC2AEJYgckiB2QIHZAgtgBCWIHJIgdkCB2QILYAQliBySIHZAgdkCC2AEJYgckiB2QIHZAgtgBCWIHJIgdkPAHYMk6cw6B6g0AAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<PIL.PngImagePlugin.PngImageFile image mode=RGB size=420x420 at 0x40746D7700>"
-      ]
-     },
-     "execution_count": 28,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "file = files[\"filenames\"][indices[0]]\n",
     "\n",
-    "Image.open(file)\n"
+    "\n",
+    "\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 73,
    "id": "666f366f",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([12, 25, 93])"
+       "array([25, 52, 93])"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 73,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -631,13 +601,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 74,
    "id": "f8932364",
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['./avatars/custom/unwed.png', './avatars/custom/eik.png', './avatars/custom/bason.png']\n"
+     ]
+    },
+    {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAACFCAYAAACg7bhYAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8/fFQqAAAACXBIWXMAAAsTAAALEwEAmpwYAABLgElEQVR4nO2dd5wkZZn4v29VV+fu6e7JO2lzYmEXWHJaEAQxoGAAA8bDxKkgnuj9TGdC77zDO/UUI2LArIgoIIIoJ1Fg2V3YPLs7u5Nj93Suen9/VHdPz0z3TPfM9IS1vvvpne63qt73rX67nnrreZ8gpJRYWFhYWBxfKAvdAQsLCwuLuccS7hYWFhbHIZZwt7CwsDgOsYS7hYWFxXGIJdwtLCwsjkMs4W5hYWFxHFIR4S6EuEwIsVsIsU8IcXMl2rBYGKyxPT6xxvX4Q8y1nbsQQgX2AJcAHcATwDVSyl1z2pDFvGON7fGJNa7HJ5WYuZ8O7JNSHpBSJoE7gSsq0I7F/GON7fGJNa7HIbYK1NkEHMn73AGcMXEnIcR1wHUAHo/n1PXr11egKxbl8tRTT/VJKWuLbC5pbLPU1NTI5cuXz2Hv5gbDMJBSous6uq6jKAoOh6PsehKJBIZhYLPZUBQFIQSKsjiXsWY7rnNyveoS4+gIet8oSBAuG7a1NWBbnN/ZUmCqca2EcC8JKeVtwG0AW7dulU8++eRCdcUiDyHEoVkenxMCra2tLIZxTSQShMNhBgcHqa6uRtM0VFXF7XbPWRvRaBRd10mlUgwODhIMBvF6vdjt9jlrYzbMdlwnXq9PPPEEQgiyal0hxMT9x1cwmiLy0T8S+d/HkdIAwBbwUX3XdSgt/tzxM1UT5/dl4ueJ20qtI7+8UN/yz3li24X2L3RcMYr1fWKbiqIUHddKCPejQEve5+ZMmcXSZ9qxnSgE5q9r40mn00QiEYaGhqitrcXtdlNTU1Ox9vJvFKFQiGg0SiqVorOzE7fbTTAYxGZbsLnUdFT2mk2kif7nX4h86wlk2gAEIJGpNDKRmpMmJgrS/M+l3jCOtzhblfi1PQGsEUKswPyBXA28vgLtWMw/i35sY7EYPT09uN1uQqEQgUBgQfqRFfYej4dYLMbg4CDxeJyamhpcLteC9GkKZjyu085C0wbx258i/KX/Q8Z0TMFuIg0DEU9PW99CCt38/kx1roW2lTJDn02709U/58JdSpkWQlwP3AuowHeklDvnuh2L+Wcxj+3IyAiDg4PU19fT1ta20N0Zh8vlygn0eDzO4cOHCQQC+P3+Be6ZScXGVULyt7sZ+diDGCNFZui6MetmoDJqmdkI58VARZ4TpZT3APdUom6LhWWxjW0kEqG/v5+GhoZFJ9QL4XQ6aW1tJZFIcOjQIWpqavB4PAvdrYqMq76ji/BH70PvjWUUMeT+B0CAnLCYerypRhYSa5naYkmSSCRob2/HbrfT1tY2I2uXhcThcNDW1oamaRw8eJBEIrHQXZoRUsqC+m7ZFyX8kftI7hkoeqxQVHBqle7iPyyLdoXHwqIQUkoGBgbQdZ2WlhZUVV3oLs0Ku91Oa2sr/f39KIpCdXX1klcHkDKIfe1R4vcdzEzUx+bt+QhVRTimF0Glfh/l6sRns99SwBLuFkuGRCJBd3c3TU1NS16o56OqKnV1dei6zpEjR6ivr19yTyJZpJSkHj5I5H8eR6YNRN4Cqsj8n1XPKMtcCPf0M/e50JdbOncLi0VKT08PiqLQ0tKy5C+6YqiqSktLC319fQDU1hbzOVpc5Nt1y55RIp9+CL0/ZpZl92Hy3N22IoBwjRfui81aZiljCXeLRY2Ukq6uLmpqarDZbMetYM8ihKCmpoZ0Os2xY8dobGxc9OcspTT7qEti33qCxN86MlumMdVrCYFj8T6BTXTQWoxOTFNhLahaLFp0XWfv3r3U1dWhadqiF3JzhRACTdOor69nz549pNPp6Q9aYKSU6Lu6Gb3tSWQq66hUHKEp2E5tAGWy+mTiy2JmWMLdYlGSSqWIRCKsXr36uNKvl4OqqqxZs4ZIJEIymVzo7hRFCAEJnejXHkU/Eh6nZ8/bizGBL1FcGrYTG+exl/PPQk9GLOFusehIJBJEIhH8fv+iDcQ1XyiKQlVVFaOjo8Tj8YXuziSyaoP0Ux3EfvkCpU60bZtqUFoDBevLf5XKQocfmK7PMzmn2fKPfeVYLDoSiQSjo6MEAoHKXghSjr1mgSHNVyW1B0IIAoEA0Wh00dnDSykhnib6zScw+mJFZu1gLqdmviQBjnNbEVXO+epmxSmkRpr4fr7VTNaCqsWiIZlMEo1GCQaDlRPsUkIqBUePwtCQWRYIQFMTlBHBcTQNTw1Bh2kUQqsLTgmCS4FKdF0IQTAYZGhoCEVR0LTF4/yjb+8kfs8+pJxO0w4gUbwajpeuK7jzYowKuVSxhLvFoiCdThOLxeZnxr5nD3R0jJV1d8PoKGzYACXo91MG3NdtCvesKNg1An1JeHmjGZylEmRn8MPDw/h8vsWxFpEyiN3xDEZfjFJEO4C2uQF18/Gtb18MWGoZiwVHSsn+/fvx+XyV10kmEtDbO7m8pwdKtEqJ6fB8eLzdtgT2hCFSYcMWIQR+v599+/Yt/CxTSoxDg8Tu2l2yWkrYFNyvPwnhdxaNpDhTvXsp+5bjqTqx/an6Vcr+5ZxP/r5TtTkVlnC3WHC6urpYvXr1/CyeFpNChlGy4lwCuhynRTaryJRXGkVRWL16NZ2dnZVvbAqkhOQ9u9GPRfJLmeyuJHMl2oYQjpetK1DXmD56Jrrp6fTdhd4XqqNYfUsRS7hbLCi9vb3U1NTMn4rB4QCfb3J5MAglJtNwKtDqnqyEaHSCf54UnaqqUltbm/NmXRAiCWK/fB6Zu6NNfJYZL+iFpuB+yymIZWao40LC83gTsAuJpXO3WDASiQRCiPnNUKQosH497N8P4bBZ5vXC6tUl6dsB7Aq8pAEcPdCdMV5pdMJFtaDOo2mzzWZDSkkikViQWDTp57pJPddTwp5m8AH7lnqc15w0yXEJpvfqnLaFCi2o5rxvC/RtOg/VQsdM3F6MufBQtYS7xYIgpaS7u3v+Y8UIAR4PrFlj6t+lBE0Dt7tkMxchoNoOF9aa+neAKg0CWmUsZYr3wwxV0NHRQXNz8/x+j1KSfGAfxlDW9n6qtiWKT8N707mIBl/FrFIWm7XLQvdlWuEuhPgO8DKgR0q5KVMWAn4CLAfagddKKQeF+ev6MnA5EAXeIqX8e2W6blEphBDtQBjQgbSUcmuxMZ9pG/39/TQ1NS2MF1/WYqa/3/ysqnDmmeAs3e56NA23H4JkJpHQai+8prlyljLFEEKwbNkyBgYGqK6unr+GI0kSD5ghfUUu0mMhTPtI95Ubsb90sq49t1dWEEpMxwEw10GEMF+KmNYYZ6GF6WKjlJn794CvAN/PK7sZeEBKeYsQ4ubM5w8DLwHWZF5nAP+b+Wux9LhQSpmv0C025mWTSCQwDGNhTfnSadPeHUwhUiYSiBljwj05N9niZoSqqui6Pq/qGf3gIKkXepFMJXNNYevYUofnXy8AdyY+UFYIpwzkYBT9yAjG0WH0w4Poh4eRR2MYegpD1xGKgmrTELVO1BYfSmsQtTmA0uJHqfWAXa3Y41I51ilLMoeqlPJhIcTyCcVXANsy728HHsK80K8Avi/NW+ijQoiAEKJRSrmwy/oWc0GxMS+bY8eO0draOje9sgCgurqajo6OeUs1mH76KMbA9OEQ1BoXvk9fgrLafKqQ0STGnn6Sjx4m8cAB0nv6SB8aQUZTyJy7b4GKsqFpFIFw2lCbvGhtIewXtmE/uw31pAaE3zGngn7GUSGzZUXqXew69/o8gd0F1GfeNwFH8vbryJRNEu5CiOuA6wDrQl98SOA+IYQEviGlvI3iYz6O6cY1Eokcd8k2FgOqqtLQ0MDo6Gjlc7JKSP1fBzItp5y1K34N/79diHbxKuTRERL37SH+k50kn+nC6I1OsDwVE/5OaFACUoABRiSFsXuQ9O5BYvfvR/HZ0TZW437TFpxvO21hwwjHUqR2dKHUeFCWh0r166oIs15QlVLKjBAo97jbgNsAtm7dainLFhfnSimPCiHqgPuFEC/kb5xqzKcb1/7+/iWRyHop4nA46O7urrxwNwySz3dPKJTj3gmPDe8Hz0I7bwXRWx4m+sNnSbcPZ8IB5zP1QmwhxuV2khJjJElyVz9uwfyaK01El8S+9ijhL/wFtd5H8GfXoKyvWbDuzFS4d2fVLUKIRiBrD3UUaMnbrzlTZrGEkFIezfztEUL8Cjid4mNeMiMjIzQ0NMxxby3yqaurIxKJ4PV6K9aGTBnoe4cKbyMj2N90IiIlGXzVj0gfHMqzhZ9VyxM+mU8OSpUd/8cvwPnWrWBbQNcd3SD9XBd6XwIZTqF3jiyocJ/pN3EX8ObM+zcDv8krv1aYnAkMW/r2uUVKiZFKY6RSGOl0JSwEFCGED0AI4QFeDOyg+JiXzODg4JLNDbpUcDqdDAwMVLaRlI4+Es9EgByvTlFcKq6zl5F6spORLzxCat8gUp8w2y5ZVzH1vgJQgk6qPn8xrvecCSUk2y6HcsMPYFdxveN0XC9Zhed9p2M7ZZl5BgsUfqAUU8gfYy6k1QghOoBPALcAPxVCvB04BLw2s/s9mGaQ+zBNId9a0plYlISUkv7HnuSF//hvjFQKm9vFpk9+FP+6NXPZjA34a+aHYwN+JKX8gxDiCQqPeUlEo1Hq6wuq6S3mmLq6OmKxGC6XqyL1y3jajJ42LkMqCEVB8dqJP9qJEU6N2zan7Wdqta0KUPW5F2N/1YaSZ+yVtIUXQmA7t43Ar99omm6qYn4dHyZQirXMNUU2vajAvhJ472w7ZVGcY3f/gYEnngJAsWskB4fmuomklHLrxEIpZT8FxrxUent7LV37POF0Ojly5AgtLS3T7zwT4mlIFxCQUqL3xTPCszJCTWKGMXBe0IbvcxdjO7UZROlCuxzBPmNrGbuaK7M8VC1KQqbThPfszX3WAgG8Kxa/wEyn07jd7oXuRo6il4QscaKVvfAKVrawqdWyOJ1O0ul0RUI7yLRe0L49G899aqem2aHWuPC+61Tc15+NqKvwwnEJyDybfQA0ZVzIgoXEEu5LiNRImGjH2Pq0d0UbWjCwcB0qkUgkQigUWrD2sxdgLGUwEDcY1hVGbHXE/VXoCGwKuEZU/E4zjEDIDo7MU74QjDndpNMQi0EshiOa4NzhFBgGOoKqlIZhd5JyOFA9bmx2LXP8wlzkHo+HoaEhamrmfkFvssVLJcncSD02XBevwHPjOdjObANt4WMeSikhoZO8+3kSd72AlBLHS9bgeOUmpGvhRevC98CiZOJd3SQHxjz+qzZtRFlEGXmKMTQ0RCAQmNc2swI9kZYcjBjsGjI4nFSJpBUSUkFqrVCVd0CvOet0qeCzwQoPbPRJ2hwG6sgQorsbBgbMeDTpNE4puSi/wREwugHVhrA7GPUHsDXWY6sOodrMx/T5FPRut7tyESP1rHAv53zK2XdMl694bdjPasb9ztNwXLIGfPO3ID/dAqY0JPEfP8PwjX9ADiVNr+VfvYC/P47rPWcg1JnfgObFQ9Vi8RDZfxA9nglDKASBzScubIdKIJFIUFtbO69tSilJG5LnB3X+NiA4llJI5//Ui1wTEojqEE1LeuOScNcAodhBAqNDoOvTtqsAip6GWBpvbBS9p5OUz0+ytQ1HQx2KqsyrgK+uriaZTGIvI31gSRTSt88JmVm6TaA0uHFuW4nrDSehndUG/vm3sppO5y7DCWLf+zvGUDJXZoymiX3377jeuAUZKByryNK5W4xDSsnI7j05FYFit+NduWJR6PamIhwOz6u+XUrJQEznvi6DF2I20vnWvrkLxpTvqpSoGOgo6EIgEUgkXiPJBSMHOHn0KE6ZLuwzKQQ6CoYQKFKiynzrkWz95qxf3zlCvLsO29o12L3ueRszIQSjo6NzLtxlOjtzz7eWyeiZXSok9AJZSwRjdi7j474LVSA8NtQaD/bTl2HftgJt20rUFUHQFrEnc0rH6IlNKjYiCWRSH/vdSJBHh9H396O0BlDagmYYhQr/DizhvlQwDMK79+U+qm4X9kDVFAcsDgYHByui952ENLP9tA8muatHpSedF39XSlQB9bY0bW5Ji6ZT7VZx2lWEUJAIYgb0JyVdA1HWHN7Finh/7rYgAR1Br92HqyZIVU0VuN0oNjMQlmFIoskUyUgUx8gwDA3ijIYRUuaEvLu3i8RohMj6jXhrg4CouJWc2+2mq6uLYDA4txUbRWaMTpWqT1+IUG2kDw+gHx1GPzyC7E9C0kBiIFBMwVbrQF1Rhdrkx7a8Gm1LPcqKakS1a87t1SuF8DuwX7SC5O7+3P1KKGA/txVRNTZr1585xvA7f01qzwBqk5eqr7wc7cJVFe/f0vgWy6TY48pM7pRzWddU9U5Xn5FKEe8ecwq1V1WhVfln1Yf5YL7C0Epg30CSX3erDElbzpRFBVY605wRglavgltTEKLATFZKWoghe56D+FBufmkgaHcE+ZuvjUP2IDVejVfXCELaWM4JFdAAT3UAKRtJJ1PE+wcRhw/jGB7ICXlHNAI7thPZuAlvfTXzYVkTCATmKRSugISOsCk4rz/TvAGkdXPxNalD2kAaEqEIUBWwqwi7AjYV1KlnsQsVyndanbum4rnpXIyuCIlHDgMSxzkteD+6DRyqqVIxJPFfPU/iyW4EkB4ZJP7D7WjnrZjyqcTSuechpQTDIN7bR3j3XiIH2klHIkjdwOZx4129kuCWk9ACVdN+KVJKpK4TPXSEoed2EuvqRh+NIqWB6nThXd5K6LRTcNTVlizkpZTIVIp4Ty+RA+3Eu3vQozGkYaDYNZy1tfjWr8W1rAGhqpPq1RNJUiMjuc++tatQp1B3GMkkg09vzx2jut1Un3Yqin3+FmANw0CbhwVfKSWHIwa/6bExJNVsIT7F4KKQzknVNhyaUlyUSgnJJOzciRgaGivXNI41ruTXNDNg2EAIDsfgt8fg1c3gKRBtVgiB5rBja6xDrwkRO9qJdmA/WiqBAJzJOMrzO0nZN6MFp/8tzhZN04jHp4/eOHsk0oD47/fifPtp4NbMxWVHYSFUTGBXWpDPpROTEAJleZCq21+NftCcvasrQuC1jztnxWtHqAKpS1Ml6LPPi3PTkhfuWaE+9NxO2n/wE3offoRE/wByQiZ7YbPhX7+WdTdeT90F5xYUoFKa0eeGtj/H/m9+j75HHiU5NDxmCpdFUXA3NbLm+nfSctUVCJut6EUqpUSPx+n7699o/8FPGNq+g9RIeHL/VAUtEKDmzNNY+75341u3Zlyd+miU1Eg49zlw0qaCq/HZ9vZ97Vvsu+27yJS52KMFg1zw25/iWtY4/Zc6R8xHzHYpJcMp+F23YFDPKNOlpFZNc0WjpK1KQ5nuQpISDhwYS94B4HAgNmxgWV0dl4YV7u6CcGbI9o3Cw31waX3x5BxCCGx2DXV5CzGPF2PXThzxUQSgJWLoLzyPPHkLwums6IWuqiqJRGKOKxVmGpcCJB89Rvq5LmxnzJ0DVTku+6VsKzcu+7Rteu3YTix8XQkBzjdsJvnMURIPHUY7pR7XO0+flwBnS1q4SylJh8Ps+/q3ab/jznHCb9K+6TTDO3bx1PU3sfZ972L1dW+dlDMzNTLCgW9/n0M//CmJvv4iNQGGQfTIUZ77xOcI793P+hv/GZtn8ixaSsnQs8+x+9av0vfXRzGyySEK9U83SPYPcOx39zLw9LOsvf6dtL7uKpSME0q04yjpiJllXthspnAvcHNK9Pax499uofP39yHT5hVo83pZ8ebXY5/PTD2Ywr3Si6m6hId6JUcTGVdvKalW0ry60aCpyj79xSqlKdSP5sW3s9nMPKv19ahCsNFvqmh+fQzihvn+qUFY44XVnqllsxACV22Q0RNPQm5/FmciaurhR4Yx9h9Abtwwp7P3I0eOcO2119Ld3Y0Qguuuu47XvOY1AKoQ4n7mIHuamEK468NxYnf8Hd/Jy8xEGnPATPKfFpy4zbKOon2TIAeioCqIgNN8QsweKwSiyU/VN69E7xlFqXYh/M55cXVbeE+AmSIlejTGc5/4HHv/99vjBbuiYPN5cdTVYvP5zKTIGfRolL1f+yYDTz0zbiCNtM7er36TPf/99XGCXagq9uoQnpXLcbc0oeQFvjLicQ5+7wf0/PmvBRPr9jz4MI//0z/T8+BfxgS7IrCHgnhXrsC3djWelctNR6S8PsaPdbHr818ivHtvzoU5su9Arg7N78O7asWk9qKHO3j6hps5dvfvxwS7z8vmWz7F2vdeh+qYY5O4adBLMB+cDVLCwVF4dtj0i0RKXOi8rCZVmmA3Ownt7aaDEpgXZVsb1NfnLlBFwEY/nJkXnjtuwF/7IFXCE74QAk/IT3zdBpKqlrMZUTqPmbbzc6iKsNlsfOlLX2LXrl08+uijfPWrX+Xxxx8HaMTMpLUGeAAzkxaMz552HWb2tKmZyoFIQuznz5N+6h8nGGzqkXYGX/J9hl79I4w9fZO8c4UQCK8D28oQSpXL/F1aapniSODIL37D0d/8LpcmTWgaDS+6gMbLLiGw5SRsHjfp0ShDz2xn3ze/x8jO5wFIj4TZ941vs3XziagOO1JKOn79W9rvuHPM1NDhoPnKV9BwyYVUbViHzetF6jrhfQfY+5Vv0PPQX8x+pHW6H3iIxssuzg2YlJKBJ5/muY9/lkRPr1mfXWPZyy+n/qILCG7eZOr+FRWp6ySHhhh8ejt7v3ob4d1meIF0OMLR3/wO/4Z1IATDz+/Orci7W1tw1IzNwqWUDP79WbZ/9JOMvLAnV+5bu5r1N72PhosvRCxAcgxFqezcIS0ljw5AUo5dKGd6EqyudpUm2KU0hWu+nt3ng9bWcTdbMJ+izwzB7gh0ZlTYh6LmzWWtd/prVQiBv6GGoYEWQh0HzDJdxzh0GILBORufxsZGGhsbM6fiY8OGDQyZ5xfAzKAFs8yeNqYOzD9pkfvf6IkzesvD+G+/ChEoHLysnEXCYvbmM5lpl6pzL/lpSkLi57tIPNWJsAlSDx7AsXbhwvzmsySFu5SSeGc3+2/7LjI7O1QUlr/xajbefAOKwzFucDzLW/GtW8Pf3vAOkplwqINPPUO8uwdPazPxzi723PpV9GjUrMrp5ISP3kTb618zyQM0tPVk1t/0fgaefDqnJhne9QJ6PI7N7UZKSazjKM9+5BNEj3QAYPP72PAvH6D1tVeh2LVJPxzN78Pd0oyjOsTj73gvesyUHr3/9xjrEkmETSW8d8wMsmrj+twThDQMuu7/E8997DPjrGm8q1ey9X//C++qlQtmC1/p8L7dcWiPZj5ISY1IsbVOQynVM1BK6Ooac1ASApqboYhduNcGW4Pwu04wMGftz42YybFLEc2qInC0tRDt7cKdUc+IwQGIRKBq7s1a29vbefrpp7njjjt461vfaptN9rT8DFstnqmFl0QSu3c/2tcfx33TeVNahUwU3FPWW+DpuNjnqdbASqHk+DACHC9dS+LB/QiPA+2c5fmV5O03/9fgklXLHP7ZL8fFWWl+5ctY/8HrUScIdjAH2rd2DdVnnJorS0VGSfT1I6Wk+09/JtpxLLet5aorCgr2bF2e5a04G+pyZUYyicy4ZMt0mt23fo3I3v2AeaM48ZMfZfnrX4fqKK4qEEIQPPkk3K1jC1GpoSH0eJxUOEL0cEd2R4JbTM9UPZnk0I9+xrMf/viYYFcUlr38JZz29S8vqGCfD/ZGTPVIlhPcKarcZVjnJJPmzD2LwwG1tUUvRCFgvdcU8lkOjkI0XXD3gri9TmK1eQlL0mlkBcIERCIRrrrqKm699Vb8/vEms5lZelm6ICnlbVLKrVLKrTXeYGaeXrgagUAmDSL/9TeSd+3KXRsT6isoaLPl+a+FYmL7hfolAO1Fqwj94S0Ef/MGlE2mXJBJndTjHcR+vJ3U9k4z2FoZ55O/b7Hv4rj0UE1HRjl2z325O6Ojppq17383ms9X9BihKjjGucFL8/iMCmWcOuaKl+YWMicipSTZPzAu1K49GMypd3offoRj99ybaVTQdvVVNL3i8tLiTAiByFMHCJsNoSrEjnaSHDRjyiiaDe/qVRjJJLv/8ysc+M73MZJZfb7CsssvZfPnPonN5z2uBbsuoX107LOGwfpAcaulSUgJ4bAp4LMEAqaAnwKvDVrcsDNjlTqaNtU0XltpkzNFCBz1taSPtqPJjNAbGESuMMaN/WxIpVJcddVVvOENb+DKK6/MFqfFHGVPE06bqXcfF0BssqDRe2MM3/QHAm4N7cVr58Urc94RwlxgbsyTPYYk/p2nGPn4AxhDCZRGN4EvvxT7KzbOa9DQaX9NQogWIcSDQohdQoidQoj3Z8pDQoj7hRB7M3+DmXIhhPhvIcQ+IcR2IcQpc93p2LHOnMoDwL9hHe6mZVMfZBjEu8byPtrcbuyhIKnhYQb//myu3Ld6JVUnbCh4pUopSQ4MsvvWr5LsH5vxhU47GaFpRPYdYOdnvogeNV2Sq8/Yytp/fheiwI0idzc2DKSuYyRTxLu6x6lWnA31qC5XJqaMqapRnS6MVIodn/w8B75zR55gFzS/6uWc8K83HfeCHcz4L8NpyF4tVUIn6CxTOIbDufUaAPz+aSW0KqDJOXaNpiR0l2lpqLpdJO2mB6MAiMeQU1hSlYOUkre//e1s2LCBG2+8MX/TEHOVPc2pIjSlpKl/uj3M0Ht+S+JXOyBlLOhMvFyEKC8TU/YlB6JEv/Mkem/MTEl4OMLofz8KiXRZZp3ZfadqcypKmbmngQ9KKf8uzPRrT2VMqt6Cufp+ixDiZszV9w8zfvX9DMzV9zNKOqMSSfT1YSTGZlym48/Up5KOjBLetz/32dlQj7O2hsj+g8S6x4R+1YknoHrcYz9CKU0zxcFBev78Vw5+9wcM7xrLF626nNSdfw4YBvtv+y6RA+2AGftl9Tvfhr06lKlGYqRSJPv6Ce/dT2T/QUYPHyHR20dqeBg9niA1PDLuicC/YR3CZjMXWY3sI5rBjk99npFd43JWgyHpvOdeRna9wMq3vYllL3sJqstZ9Afwtre9jbvvvpu6ujp27NgBkE3PtkYIsZdZmstVmnjKIJYCUEFKvA4Fl1bmDW00b+ovBHinXxkVAmodpgVNNnxKX2Isakop2Bx2pNOBzOjd9WQKkulxllgz5ZFHHuGOO+7gxBNPZMuWLQB87nOfA1OHfomYi+xpmooScmJEI4yddfGzT7eHGX7n3Xh39eO6/gwIji14l+KpPZc3hLl0YirahiQXOVNk4hUR08tUhM2eUjIxdZJZXJFShoUQz2MuuFyBmX4PZrn6Xg5SShI9fWMLqYBv3dppr6zRw0eId+YJ8RM2oLpdDO96HiPPySM5MMi+//0W6WgUfTRKcniERHcP4f0HSfT0jmtX9bhZf8P1hE49ma77/8Sx399vbhCC1quvoubsM0FKhp7bRec99zL47HNE9u4nOTSUM1UsihAETjwBjEzAsAzpcGSyYM+gx+KMPL+bZz/ySTrv+xObP/9JnLWFF7/e8pa3cP3113Pttdfmym655RaAsJRyzXzfsMslLSFtkBt3l02glhFiVUpJMpYgK06lEKbjUgnH+mwyzzYEwol0JtBBaeJdUwXpvKc5aRjjnyBmwbnnnltMeOlSyjnJniZsCrY1IdIdkVKPQB+IM/LZP5N67AieD52D7czWBYkhMy9PDiE3rqtPIrX3z8hoGtXrwPWOU8A5v+dbVmtCiOXAycBjQP1sVt9nQ2T/wZyOXGgaVZumdgSRUjK88/mcagMww+UKwdBzu8bdUbvue4Cu+x6Ytg/2YIANH76BltdeSexoJ7s+/yXSYdPWvuqEDax7/3uQhs7+b/6AfV//zrg47KUgbDbczU0Y6RSJnsILbkJVUF1uhKKQjkZzXq8ynab7jw+yt6mREz724YLrB+effz7t7e3jyn7zm98AZI385+2GPSMmXKQK5We/SafS2LJLg0LBUGyU4gngwsAmBUamD/GUDlIteeouhMDI068vIU2FiaKgrasj8dCRArPR/EiRYwhAJg2i9+wj8XgHzlesxX3tKdi2LAOvHZlxVZipOnGqxcZyFjEnfp5Rf1SB671noW6sRd/dh3ZyE7azW+fdYKZk4S6E8AK/AD4gpRzJP2kppRRClPUTzTetam1tLfk4qesM7diV++yoDuJdsXyagyYvmgZOPAEjkWB41/OldhjV7cK3ZjWNl11M/YXn41uzGikN9n71G4y2H87VvfZ970Z1u3nu45+h45d3jZvtIwSa34eraRneFW04GxuxB6sQqsqhH/40t5agOuzYQ0GMRJLk8PC4rihOB8suv5RlL70Uz/JWFJuN0UMdtP/gTrr++KA5C5SSwz/7FY2XXkzN2aVNsrtN9VRW+TujG/ZMx7VcbMhxP96UKC+9mUTwTHAFXZp5uooiOEdxUDfNcQD+VJSXDR7CyKjKXEEfgraS+y6lxGaM/SZ0oSDEEjJcE6Cd3wbf+vv4x6cS0fvijH5nO7FfvoB9cwPOF69CO70ZZV0tit8JDtUMLjZbYViOrmyKKmaEXcF+6Vp48ZhWoZDVUGkIUw+Yc3ot7aRKEu5CCA1TsP9QSvnLTHH3bFbfpZS3AbcBbN26teTvMD06SuTAwdxnz/I27NNk+dHjcYZ3jglxR3UQT1sLycGhMRNDTEcjm8+HYrOhOB1oPh+O6hCe5W34N6wlsPlEPCvaUJ3OnO6u989/4+hvf5+rY9lLL6Vu27kc+fmv6fjVb/Ps8AWBEzfRctUrqD3vHHOx1OnI6Xj1WIyOX/02V49WVYU9GCAdHR9TRnHY2fSxm2l93ZXjYtq421oJbjmRJ6//IL0PP2LWORql894HqD7r9LJnIDO5YWeOm9G4lotTGDiBCICAWBqSusRhK3n6THdVPX/P9FAVsF6nJOFuj0c5efTo2JQ71FyWEDHS+rgF1LRNm3bNaLFh29SAWuMi3TVaYI5eiInlEmMoSfzPh0n89QjCpaIEXdhWB1BCLnBnZvMWCCFQvS60M5dhv2AlNFWV9JQz7S8qs5j2beB5KeV/5m26C3PV/RYmr75fL4S4E1MvO/3qexnEjnaS6B1TU1Rt2ojQpj6NWMexcdY13lUr0QJV9D/+FKnhsUiLjS95MRs/8kEUux1FsyE0DdVuz3krTnhaIbL/IDv/7Rb0UdOTJnDSJjZ86P2kwxH2f+v2nJpEdblY+7530Xb1q9GCgYKDkujpG2cp41+3Bs3vZ+jZ7aSzwl1RWPm2N9HymldNssEXQmDz+1j97nfQ/+jjOSua8N59yHQaUUJ0xvr6eoaHh7VMfbMyl6s0bpvAb9PpS0sQgpGkzmhalKzGFZgLo1kMCb1JWC+nWVOV0lyIzX+E95SXqNlIJJHxBDbMmaHhcKLNY7TOuUBdHsC2oYZ0V3ZReqr7uJhiu0DqICNpjEiY9JHC8aHmW3O12O4rAuCbCtr6EN6bzsPx2hOR08TuKeVZ8BzgTcBFQohnMq/LMYX6JRnLioszn8FcfT+Aufr+TeA9MzqbAkgpCe/dn/PgBHBOE3ZXSsnwrhdIR8YsIzxtrQhVJdHdMy46o7u1GWdDPY7qEJrfj83lykWPnBSISNfZ/63vmfp/QNhUVv3TW3A2NjDywp5xTwSNl7+YVde9FXsoWNQaoO+xJ8bdaGrOPsP0TN1/MBdTxrtiOav+6a2oRQSBEAJ38zIU51iiACORLPnKeMUrXgGQjWswO3O5CqNoNlrE2EJ42FDpTZR3SdY5IGtgI4GjsQIJhCZiGJCvJlMU08qmDMRoBFsyr++eKpy2JaSWAfDYcbx4FUIxPVJnjyjwmnpr8Zcoc//iLY8tnIsC28b+lXIWpfVTjCvPIjHXLJLb+xh6993EvvFERiVWnFKsZf46oZ185mT1vRyGnt0xbtYUOdiONIo7gOjRGEfv+t3YAqyiENp6MsCkKI1KiY/GeiLJgW9/34xrAyCg+VWvoP7ibQghiB09Nu6mEdxyUtHYIVJK4l09HPzuD8Y5ZdVfvA3AtIzJlDe+5BLsoeCUU0s9Hh/XtrOhDmGb3PY111zDQw89RF9fH83NzXzqU5/i5ptv5j/+4z/8mRv27MzlKoxQFFa7DR4ZMkgLFUPAjiGDNX4xfYhfzK+w0QluGwxnfgaHoxDRITCVnE0mx8eisdtLso/PIg0DvbMLNSMQ0yjooer5iAA7twiwX7gSEfo/ZF+c0ue62f1KuSGUs+9iY6JoLveYYnsIjNEUkS/8BftpU/v2LClFn0ynGXlh97iy7gf+THjfAXxrVk1Sm8h0mgPfuYOeP/81V+5ZsZza88829Viu8UGNIgcOmjryArHes3UaiQT7bvsue//n6znVR9UJG9nwofeP1TdBkI8ebDcFdIEwpEYyye5bv8LI82Pn1XjZJXhaW8xAZZkwBigKwZNPmnb4Rw8cGkuiDfjXry0oeH784x8Xq2KPlHLrhH5W9IY9UxqrHNQPxTmKByTsiSr0xCQN7tIEjccGK93wdGYiHknD7jCcXuz+KSX09Iz3aq2uhjISkujhCGr/mFpxyOnDF1r8GbUKoW6sw76lnvgfDy10VypKKb+m+b43650RRm97Ysp9ltSzYGp4JOcklCXR08vTH/wIPQ/9hdRIGCOVQo/FGHl+N9s/9mn2/M/XczblqtPJuhveiz1kOhb5169Fy8tD2nX/n9j5mS8SPXQEI5VC6jpS19GTSWJd3Rz+yS947K3vZu//fCMn2B11tWz6xM3jsjL5165GdY/dOI784i4Ofv9HpMJh0xs1nSYVjtDz4MM8df1NdPxybCHVXh1i+ZuuBkUhHY4wesg0UlEddlwNDVPOEKWUDD797FiUzCJx3+eLOU8SMQGnx8kWRwyRuXFGDMEjfZJUsRyfE1CAE6vGVDMG8MSgKeQLkkhAR8fYk6OqwjRjko/UdYz2dtRUEpFpb6h2GVWuys6x9u3bN/1OM0B4HLiuPMF0v18ys+vyr4VSAvGUFqxnsrppJggEUkLyb0em3G9JzdzjvX3jPDizDG/fyRPXvc/UmdfVkgpHGD14KBe1MUvjZRfTeNnFOWHnWdFGwyUXceRnvwJMJ6CD3/0Bx+7+A97VK7FXVSGlmUQjeuQoid4+0+Ekg6Ouls23fIrQaaeOE6C+taupPu3U3BNDaniYnf/2BQ7/5Je4W5owEkliR48xeugIRt4sUHU6WX/D9fjWrkYIQby7JxdTRnU60YJTRw6U6fQ4M1Gbz4tn5fISvtnKYMyRY04xhKKwqdbBkx0xuoUbJDwXFqwc0NlcrU6rnhECVnig1Q37M0sy3XF4bBAurJ2QLMcw4PBhM4JjlkAAglOrybJIKUke68LW3ZUrG3J48TebCUEqSSwWq0i9Qgjsl61FbXuE9IFhplo0HaOcm0Bhm/kSezfF8aXWN9c3rLmtz/zOi7OkhHuitw+ZHtOT23xec6E0o96I7DtAZN+BSccJTaPlqlew7obrx8V5EarK+pveR7ynl9481U2it2+cRc4kFIXQqSez8SM3Ejxly6SZseJwcMLHPkyss4vwHnPWJHWdkV0vFPUuddRUc8LHPsyyl16WWz+IHDiYWzx2NtRjD0wt3JODQ+PO39PajDMv7vt8YysSfG3OEAJflYezh4a5a9SJLhRSwL19Cn67zkpfYfVaPpqA82rMxdS4Yc6m/9ZvLrZu8meSYEsJ3d2mcM/O2m02WLFikgquEFJKUv0D2PbuQTEMBJBGEGlaTpPfUXHnloolKRegNFfhfuUGwv/1aAWdscqteOKTxEI8VRRoUwAOBZLSTBZe8Jjpfgx5+6hizCulAEtKLWMK9zHnj9Xvegetr7sKm69wTBChqjgbG9jwofdz4qf+H876ukmBgJz1dWz+3CdpftXLsU0VW0QIhKbhbmlmw7/cwOnf/mpBwZ6t17t6JVu++GlCp51aMHQwAIqC6nGz7KWXccb3vkHTKy5HyZh1SilNx6iMysG/Yd2kNYKJxLt7xyxuhKBq00YUh3PKYyqJEIJoNDr9jrNrhBMbPazV4hnBKwjrgl8dExwYTue8SKc4nJUeODU4dlnFDbinC3aNgG4YpmB/4YXx2ZqamyEUmnbWLg1Jorcf8dwOlGQiJ3aGg3XUtDUwRdruOSEajVY21aFNwXnNZpTqqX+bFmDbXEvoh6/G8dr1JavypkJbG5y6vVm3ME9kQwhkURwOas87i6oTNrDyrW9kZM8+RtsPkejrR7XbcTU34Wlrwb9+Lc76OlM4FxHErqZGtvz7Z8YCerUfJt7Tg0zrqE4HjtoaXMsacTXW41210jRpnCY8qxCCwJaTOPN7X2fouR1EDrQTOdCOHoth83hwNtTjbmnC3dKMd9UKFG1yEo9ll1+Kq2kZCAietGnaH4R3RRun3HqLuaAqBKFTtyyowa6iKBVPtSeEwO7QuKRR0nNUp9+wAYLBtMJPj8FF8SSbqzUctuLhZhXg/BroicPejHomnJLcdzRNgCM0dR5E5FtWVVfDypXTrn/oqTSJjk7sB/dhy+jZARJON/Z1a3DZ1YrP2nVdx+ms7A1ePbEe18vWMXr7s5kJa3Z2WWgmWo5+fnHo8mc3RLnQYWhnNWF/2XqMRIrEr/eMT0ZQFtK0VrpoFWwvvtfSEe7p9LgUcvZQEHfTMhSbDf/6tfjWrZl0TFnhNTWNqo3rzbR2U+xXDkIIbF4PNWedQfWZp5dVpxBmUhDP8tJd+G1eD42XXVJWHyuJoiik5iiU7VQIIajz2bm8Ps1vunVGDDWzwKpwd7+d58MpzghBq0/FrSkFQqeCR4WXL4NfdEj6IinaEoOcFTlEY2KQrICRAIEAYuNG00KmiEVVOpEiOTCIOHwY1/AAQo49gqfsDuT69XirPPOy0J1KpfCWaYdfNnYV13Vbid29B70vmmf3Xez8lp6AnwsSP9/NcOJXpJ7qgrjObG4bsVVBnG/bCrcW32fJCPfk0PA4SxnvyuVoVWMmZHN1oVTqgjve46sXo7+/n1DGOqmyCNYFbVwl0vyuW9KTNgW8AexNaBzogrreNC1uSZNdJ+RWcdlVVCEQUhKKjxAajfDa8DDx/kFqkhFUxoSyARxw1rCnbiPLki5qkTQaoyiYtuupRIpEJIoWHkEODeGKRcYJdQmk3F709Rtw1obm7YFqaGhoXr5/2ynLcF9zAuGvPok05iCoyyKm0JlN8QyX2270xoh9Z0fO6WumJpa9jV4OfugiLttQW2DrGEtGuMeOdo6LrOhfv7ZgEgyLxUUoFKq83pfsJFqwKmDjjQ6dP3aleD5mI4UCQqADnWkbnSMghJqLfSkAh9R5X9fT+NNxAhPqlUBc2HjK08zD/hWMxuyIo4IqPcH7uh7FIU21kyYl+Ssr+RelrijEq+vR1q7G6XXP240+Go0SDE6tl50z7Cqud55G7J49pPdPbcWx1Jhoc1PIBmcqu57x2wotpE7fNoChCp46oZE73ngWH37lBuzTeL4tGek4Lu66EAQ2n/gPOxteSni9XtLpYobjc48QgpBL5cpWhd1Daf42AEeTNlJCyalRJtpRGLJwWFipqgx4gvzetYLdWhAjY6ecPSabprHYBa0rKklvFbKtFWd9LYo6WSVUScLh8Dw9NZnfu7q+Du+7Tmf4Iw8gJ0WLtK7VmZD91kaqHPz0khP42rZNvOaUGjZXT+84tySEu5SSkZ152Y+cTnxrVi1gjyxKxeFw0NnZiafM4FqzQQiBTYUTqjXWVBkcDqfZNWxwKGkjnIa4VDAKhdgVwjRxdDjMRdO6OqqqApwdVwiEBQdGMY8vskZsIEipNoTDQawqiNZQjz0UQM2Ef5jvyUh/fz/19fXT7zgLxlmfKQLnm08h8fs9xP50iPwF1cWjNZ9bHf5UcXWmb2XqYwWgq4LnTmjgyy8/lQdXNtDg1XjXei+aMv3vaUkIdyOZHB+yt64W17LGBeyRRTkEAgF0XUctwSZ8rsj+8B2ayuqgwuogJFI6g3GDIUPwQK9BZzIj4BUF1q4Dlw2cTnC7zRAUgE0IVnhMZ6eEAYMpMxZNfBRs3eSuT93nw1i1mrTDheZ24bfbxvVjvolGo9TVlRLAeHZkn3iEEKZFWo0bz//bRmrnz0h355vBzsYhaS5ZPLeZQuRuFgI6G7zc8aJN/PistXS7nGgKXL/Oy9oqNRdyfCqWhHBPDQ4T7RiLMOusrcbmtuxqlwper5eBgQFqa6deAKoUWQHrtNtotEOdlDw+DJ1Z52BFwLJG82ooaC5r/nWq0KhCgwPQGCenFKcTpa4WbRoT2flidHR0/vTteQgh0M5djvc9ZzD82YeRSdMq5PixeRmPyD2ZTD67iTr6QkdP2ipgIOjiD+et4XvnbeCFkB89s9+ZNU7evNZTcpC5JSHc47294xJWOGpri0ZZtFh82Gy2irnAz4wi7uglXjSFJuMLPR+dSDwer7yHcBGETcH53tNJ/v0o0bv2zqFUL7SkObHy6Uai1NuMud+YEWy5I1xoubU4hgJD1S7+eOoKfnDuBrY3hkgqmTqkpNah8v+2+Kl1FvfXmMiSEO4IgT0UQI/FzZC9p52SS6BhsTSoqakhHo9X3KHGwhTs8/mUNEnYCIEIufF++mLS+wZI7ZwilMcixBTlEqEpqAEnJHT0keS0x5VTP5k2UnaFo/V+7jtrJb/cuprnq6tIKWJcJDJNEbxzg48LG0vJ8DvGkhDuVRvWcf5dP0XqBkIRRZNeWCxe3G43hw4doq2tbaG7ctzT09NT0fy1+Ux1Haon1OP/9xcz+LZfo3fNRRiKiTPgQjPi6WbZU8+iJaA4Vexb6rCvryH5dDfJHX0lzN2nV8JktxqqYLTWw8DpLdy6qpm/rGykx+NAn/RdShQhuLrNww0bPdjEhAXsOUiz5wQeBhyZ/X8upfyEEGIFcCdm5p6ngDdJKZNCCAfwfeBUTGvi10kp26drZ8o+qCrOuoXR1x6vvO1tb+Puu++mrq6OHTt2APDJT34S4CQhxDOZ3T4qpbwHQAjxEeDtgA68T0p5b7ltBoNBEokEDodj+p0tZkQ8Hp8388dpEaBdshb/xy9i+EP3YoymmFlUyMqSm0krAsfmWtxXb0I/HCb6853ouUVhQaluRzIz7c4pgBRI2lW6a73sXFXDnze2UnV2G3pzgJ8djI4FXBt3BzELL6h38NmtfoL20tUxWUqZuSeAi6SUkUyi7L8KIX4P3Aj8l5TyTiHE1zEv/P/N/B2UUq4WQlwNfAF4XVm9sqg4b3nLW7j++uu59tprJ27qllJuyS8QQmwErgZOAJYBfxRCrJVSlhU4xu/3W7P3CjOfs3aYYC1TCFXgfOvJGH0Rwp//K0Zs/nweSkUAar0b95s24zh3OZFvPEb8j+2QMjKydvysvJiIlYrAUAS6Ihj1OVBXBHnK5+a5tloeb6phX0OAY24nNlXwrxur+OGB0cz3V7jGzSE7/3lGgGaPqYKWUk5KSDQVpaTZk2SSzGPaCGiZs7wIeH2m/Hbgk5jC/YrMe4CfA18RQgg5XU8s5pXzzz+f9vb2Une/ArhTSpkADgoh9gGnA38rt93q6mqSySR2e3n6Q4vpSSQSlQvvOxscNtw3nIOMJYn812MYJcdVKU3VMVMkmdn6mU34PvMiSOmMfPBekjt6Szo+bVN4bEsTx/wuwi4nw3VuugNedlX5CPtdvPPMWr50MMHRZF6AMClZH7ATTkv2F80KAydU2bntrCCbgzPXnJd0pBBCxVS9rAa+CuwHhqSU2d51AE2Z903AEQApZVoIMYypuumbUOd1wHXAvM40LKalTgixHXgS+KCUchBzTB/N2yd/vMcx3bh6vV7a29tpaWmZV7v34x1d1+nq6pr3p6JSVAVCCPDY8dy8DZnSiXzlSWTOE2z+186ytwrFpeK59iQ8H7mQ9DNHGb7x96QPjEx5bH4dIx6Nm15/HkcCXowJxjEnVGkcxkZnIkZ+lEyHInhZs4u7D0czGcMmHCgFJ1RpfPOcIFtrtZLs2YtRksmJlFLPPKo3Y87Y1s+otfF13ial3Cql3LpQ9s8W43n3u98N8BywBegEvlRuHaWMa2NjI/39/bPoqcVE+vv7aWxcfI59OeEvBPgceD/2InwfPBPFvbC2HKrXjv9fz8d7y2WknznK0D//rmTBDqZIHq52E3HZTcGetW6RElXARY1O7j8Ww5iwFHtqyMFo0uCF4dQEm1pzv5OCGt86N8gZddqsb3tl2RNKKYeAB4GzgIAQIjtCzUDWy+go0AKQ2V5FLkyTxWIm66oupTSAb2LeyCFvTDPkj3fZOByOeYn1PmUfFHCpY68ZXUiaNvZawKeQrPfvQqi6pJQFX4W2A+Bz4PnIhfg/dgGK1858uzZJQPXZ8X/2Etw3nEv6yQ6GPnAP+pHItMdO5GhDFXHb5HFf7bVhU+CFcH64a4lfU3hxk5NfHI6SnnDaihCcVe/g9guqOb129oIdSrOWqQVSUsohIYQLuARzkfRB4NWYFjNvBn6TOeSuzOe/Zbb/ydK3Lw06OzvzP74K2JF5fxfwIyHEf2IuqK4BHp9NW9XV1Rw5coSWlpZ5N2tVgEvr4czMtedSwVPuRNJuh1NPHcvO5HAU9m6qMFJKjh07RnNz87y3PWPcGq4bzkHUexn5xAN5grUUBySYqROTxJyxV33mEpzvOhX9+V5Gbvg9enu4wN5TOztJATsagkTHCXeJpggubXJxb0cMXY71RwjBy5rdPNyb5Fg0q80WuWOubHZzy+l+2rylhRYohVJ+0o3A7Rm9uwL8VEp5txBiF3CnEOIzwNPAtzP7fxu4I7PoNoBpZWGxyLjmmmt46KGH6Ovro7m5mU996lM89NBDABszOvd24J0AUsqdQoifAruANPDeci1lJiKEoL6+nr6+PmpqauZNwEsJfUn4Uy90xc3Lt8EBF9VBrb1E+SwlRKOwfz+EwxmVgw9Wrzbj0szbuchccLCF9vuY2H6+cCrYN7uK89qTUVcGCN94L8lnugvEgZ/bOaHituH/+Dac79qKHIgS/pd7Se4o38FKAilN4Zk1DWM9zNwLttY4GEkZ7A6nxx2xJeDAb1f4+aHRsQMkhDSFd6/3cuMmH0FH+eaOU1GKtcx24OQC5QcYe2zPL48Dr5mT3llUjB//+MeTyt7+9rfzgx/8YJeUcuvEbVLKzwKfncs+ZO3d0+k0WrE8s3NMWsLvumBv3lN4bwKSBryuBRylXFu6buZU7csTDJEIpFJw8snzpqLJZrlaipZHpv23QDtvJYGfvo7IZ/5E9Me7kImpFlpn5sQkAaEpeN99Cq73nA5SMvqlvxD708EpnJPkpHci7+9w0MWzDXn+BFJS41Q5r8bON/dFzFm7MAV4g0vlgmUufrAvTNLImo7CKq+Nz55cxRXLndhLiPJYLpYPv8WCUltbS19f37zp38Npc8aeJbsOdigKiVK7kE7D0FCBysOQzTlQYXRdp7+/n5qamnlprxiiSG7i0isAZWUI/3+/gsCXLkVbns2ulhW7sxN42VpcF63A8y/bwK2RvH8fo99+GpkuL3FGPk+taaDLnwleKCVOReGaNjf3H4szmDQyM3lJUFO4us3DH45E6UuYJpGaInhti4tfXlTNVSsLC/b87zX7vtA+U2EJd4sFp6Ghgf3792MYM00YXDqKKCwubEXKi1dUJB78PMQ8MgyD/fv309DQUPG2ZstUOYLHudJ7HTjfdTrBX7wez9UbUTw2xgVYmQW2VQF8n78YUetB9kSI3PIwxmBiRoJdYsZY/9Mpy0koCkiJIuBFzS72R9I8M5zCVLlIvDaFl7Z6uL8nwQvhFAJY69O49bQAXz8vyKagzUzzWCGVmiXcLRYcIQSrVq1iZGRkThaSpsJng7W+8Y/YCrDBby6sloSmwcRY6UJAba250FpBpJSMjIywatWqBdezZ/sz1ZiVvE2AUBXUkxvx3/YqAt+8AsepDQjb7ESU4lDxffBs1JMawZDEfvQsicePzfiWIYBjy/z8efUykOZvd1u9k0a7wh8745lzMgX7y1s9PDWUZNdAkqAmePtaL7+5uIZ3bvBQpU0t1PO/10JWSNnyqVgSgcMsjn9UVcXj8TA0NEQgEKjobObSOqizw+FMFOIWF5wcgJLliKrC2rXg8ZjqGSEgEIBlyyq6mCqlZGhoCK/XO60DmK7rbN26laamJu6++24AuxDiMeYhFtSs8dpxXH0S9gtWEP/xM4x++++k9gwi9and/wvhOL8NxzWbQREY7UNEv/YEMhdWoDyyxi9/PHMlx3wuBHB2tYN1VRq374tgOqIKQnaFV7a4+dtAkmORFFe2urh+g5ez6u0V0a0XwxLuFosGTdNwu90MDg4SDFYm8qcQ4LbB2dWmswaYqpqysdthxQoYN/usrGAfHBzE4/GUtPj85S9/mQ0bNjAyknPMaQbeM9+xoKYaw0Imf+P2b/Th+sC5OK7cRPwn24n9aDvJFwZKEs4SUIN2vDedjahygiGJ/2Q7qQNDs9Li99e4+dnWNRjA6SEH64MadxwYJZq58Sxz27i4wcWuwSQbvSr/tbWKc+rt5ZvazgGWWsZiUeFwOHIz+EqqaIQwhfqMBPvEirKvCpGdsXs8npIianZ0dPC73/2Od7zjHbnjAR9mrCcwY0G9MvP+isxnMttfJMq4q856QXW6ulUFZXkQ94fOJ3jPtQT/53Kc57WgVNmz1oQFVSwCcL5kNdq5y821zZ4IsZ8+lzG3nCEK/OGsVTxfU8V5NQ42hzTuPBghkjJQhGBryMlrl3tp9qr8+xkBbt8W4sVNdryaKLooOuW5z3JB1Zq5Wyw6sh6sw8PD+P1+lH/gxCyGYTAyMoLX6y3ZXPQDH/gAX/ziFwmHTeecTKgHvRKxoCZGKpzIVNsL3byL3tAVgdJUhfOfTsNx9UnoTx8j/sudxO/fT7p9GJnQ8x6iJEqVhvttW8GlIYHkX9pJ7Zp50hCBpGOZn+9t28Q5TW5anAo/PBAhKWGlV+PKNjdXLXfT6BYscyu52OuFdOWlCPj8aJvFfAYsnbvFkkTTNHw+H/v27WPVqlX/kEHGdF3PnX+pKfOyMfpPPfXUrFPanCClvA24DWDr1q1ywrb5W9wVIPwObBeswHtuG57uCOkd3STu20vy8Q5SO/oxokkcZ7ViOz0TMSOpk/jFLoyEUUY21/z9JGlN4Rcv2czpJzegC8GxqM4/rfWyrcHB5ho7TRmBDvOnU58OS7hbLFpUVWXNmjV0d3dTXV2NzWZbNBdOJZFSkkql6O/vZ+3atWWd8yOPPMJdd93FPffcQzweZ2RkhPe///0AqhDClpm9F4oF1bHkYkGpCmKZH22ZH+3i1chwAuPIMOlnjqG2BBFe03LJODJE4omOzEGlqmVk7n8hBCMXrWTbDafTWOfBbYM6l4JPy6bHLnzDWOioK/+4z7sWSwIhBA0NDQwPD9Pf37/gF0ylyYYUGB4eprGxseyb2ec//3k6Ojpob2/nzjvv5KKLLuKHP/whQBgz1hMUjgUFM4gFNZ0eudxt+frlsnTUqoKocqJuqsfxxpOxXbA8ty39TCf60fIDg2WxrQ+y+guXcOl6PyeFVFb7VfyaQMn1ccZVVxRLuFssCWpqavD7/Rw5cmRBo0lWEl3X6ejowOfzVSLBdQdwYybmUzXjY0FVZ8pvBG4up9I5s3OfUF8x2+5Syd0UJCT/1I5MzcwbVQ048H3qRdhPbJjyplOovNCNylpQtbAogN1up6WlhYGBAXRdp7q6+rjQxWdDCaiqSnNz85ypnrZt28a2bduyH5NSyiUZC6ocgTiJaJLUnp7xJqslonhs+D52Ho4rNi7a2flUWDN3iyWFEILq6mqqqqo4evQoiXmK5VIpEokER44cIRAIUF1d/Q+xpgDzp482+mOk9wzkacRLsFQBhEvF84EzcL3zTNCUBQnnPFss4W6xJHE4HLS2tpJOpzl06BDxeHz6gxYR8Xicw4cPk06nWb58+ZKM7DhfFEsIMlF1UzBZSN8oxkCsLJWM4lbxvv90vB/eBm5tyd5wLbWMxZLG4/Hg8XgIh8P09PRQV1eH0+lc6G4VJR6P09PTQygUOi5yB08n+KYKHAaTZ/CF9p/NLN/oHsHQ84+fYg0AUHwavg+eifvG88FrX7KCHSzhbnGc4PP58Pl8xGIxDh8+jNPpXDQ6+Wg0yujoKPF4nJqamuNCqC8VjO4I6KVFG7U1uPF/4kKcbz4FnEvf7NYS7hbHFS6XK6euCYfDDA0NUVtbixACt9s9b/2IRqOEw2H6+/upq6sjGAyW7Ii0lMj3pCy2vZzZ+Fzr4o3BBEwn2xWB4/RGfJ+7BO285aAq4/pSylNGIS/SYudieahaWMwCm81GIBAgEAiQTCaJRCIcO3aMUCiEpmmoqjqnwj4ajaLrOqlUiqGhIYLBIKFQKJd0/HhkYiLsUvabzT4zQQ4loUA8mWwSDyXgwPPWzbg/cC5KS1VF+rBQWMLd4rjHbrcTCoUIhUJIKYnH4yQSCQYHB+nv78flcrFmzZqy6923bx+xWIzq6mrcbjdOpxOv10soFJr+YIt5Qcb1gmp2oQmcZzfj/eg2tPNXgGNyYupy7MqLOWTNlIn28qW2OW77YvD4E0KEgd0L3Y9ZUsOEYEtLlDYp5Zx40Bwn4wrHx9jO5bj2AqMsje9kKY3dTPpadFwXy8x9d6GkzEsJIcSTS/0cKsCSH1ewxnYiUsrapfKdLJV+wtz31bJzt7CwsDgOsYS7hYWFxXHIYhHuty10B+aA4+Ec5prj5Ts5Xs5jLlkq38lS6SfMcV8XxYKqhYWFhcXcslhm7hYWFhYWc4gl3C0sLCyOQxZcuAshLhNC7BZC7BNClJUoYD4RQrQIIR4UQuwSQuwUQrw/Ux4SQtwvhNib+RvMlAshxH9nzmu7EOKUhT2D+WUJjet3hBA9QogdeWXWmBZhsY3rUrsuhRCqEOJpIcTdmc8rhBCPZfrzEyGEPVPuyHzel9m+vOzGSgmnWakXoAL7gZWAHXgW2LiQfZqir43AKZn3PmAPsBH4InBzpvxm4AuZ95cDv8f0cj4TeGyhz8Ea14J9PR84BdiRV2aN6RIZ16V2XWJmu/oRcHfm80+BqzPvvw68O/P+PcDXM++vBn5SblsLPXM/HdgnpTwgpUwCdwJXLHCfCiKl7JRS/j3zPgw8DzRh9vf2zG63A6/MvL8C+L40eRQICCEa57fXC8ZSGteHgYEJxdaYFmbRjetSui6FEM3AS4FvZT4L4CLg50X6me3/z4EXiTLjGSy0cG8CjuR97siULWoyj0gnA48B9VLKzsymLiAbKWpJntscsdTP3RrTwizq818C1+WtwL8wFqeyGhiSUqYL9CXXz8z24cz+JbPQwn3JIYTwAr8APiClHMnfJs1nKMu29DjCGtOlwWK/LoUQLwN6pJRPzVebCy3cjwIteZ+bM2WLEiGEhvkD+qGU8peZ4u7sY13mb0+mfEmd2xyz1M/dGtPCLMrzXyLX5TnAK4QQ7ZjqrIuAL2OqhbIxvvL7kutnZnsV0F9Ogwst3J8A1mRWjO2YCwd3LXCfCpLRd30beF5K+Z95m+4C3px5/2bgN3nl12ZW588EhvMeE493lsy4FsEa08IsunFdKtellPIjUspmKeVyzO/tT1LKNwAPAq8u0s9s/1+d2b+8p4/5XCkusnp8OeYK937gXxe6P1P081zMR7vtwDOZ1+WYerAHgL3AH4FQZn8BfDVzXs8BWxf6HKxxLdjPHwOdQApT5/l2a0yXzrguxesS2MaYtcxK4HFgH/AzwJEpd2Y+78tsX1luO1b4AQsLC4vjkIVWy1hYWFhYVABLuFtYWFgch1jC3cLCwuI4xBLuFhYWFschlnC3sLCwOA6xhLuFhYXFcYgl3C0sLCyOQ/4/J3gg25b/d3cAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAACFCAYAAACg7bhYAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8/fFQqAAAACXBIWXMAAAsTAAALEwEAmpwYAAB2c0lEQVR4nO29d5hmWVXv/9knvDlWztU5p+nuyXlgQDIMKCAKKAoGvCLiFfV3rwEV9YLiver1YkRyhmEYwgxMgGFCd890zqFyrnpzOHH//jhvVVd1V3VXh0pNfZ/nrXrfE/be5+x91ll77bW+S0gpWcYylrGMZdxYUBa6ActYxjKWsYzrj2XhvoxlLGMZNyCWhfsylrGMZdyAWBbuy1jGMpZxA2JZuC9jGctYxg2IZeG+jGUsYxk3IOZMuAshfkYIcUIIcVoI8eG5qmcZ84vlfr0xsdyvNx7EXPi5CyFU4CTwINAD7AHeLqU8et0rW8a8Yblfb0ws9+uNibnS3G8BTkspz0opTeALwBvmqK5lzB+W+/XGxHK/3oDQ5qjcZqB70u8e4NaZDq6pqZErVqyYo6ZcPVzXRUqJ4zg4joOiKPj9/isuxzAMXNdF0zQURUEIgaIszuWOffv2jUgpa2fYfdl+FUK8F3gvQDgc3rVhw4Y5aed8wzJNnMp4UIRAUVU0VUMoYqGbNitca7/CdepbR+L2ZnFGCiBBBDW0dTWgLc7nYbGjo6ODkZGRaQfhXAn3y2LyQGlra2Pv3r0L1ZQJGIZBLpcjlUpRXV2NruuoqkooFLpudRSLRRzHwbIsUqkUyWSSSCSCz+e7bnVcC4QQnddyvpTyk8AnAXbv3i0XQ79eK4qFIr//W/+Nt95zG0FFkkql6U3nsDU/WqKKjTtvYuv2bQSCQYRYnML+WvsVLu7bPXv2IIRg3LR74bVfZPItWOT/8HHy//cFpHQB0BJRqh9+L0prbOL8qzUVT27Lhb8v3DfbMiZvn65tk6/5wrqnO36682bCTG2ffO7u3btnPH+uhHsv0Drpd0tl2wQuHChz1I7LwrZt8vk86XSa2tpaQqEQNTU1c1bf5BdFVVUVxWIRy7Lo7+8nFAqRTCbRtAV7514Ol+3XGxGmabKqOsno/ueoVSwSqkZ7ogp/WMHRivS+9Dxffe451t1yKztvvRlVVRetkJ8Bc9+vhk3xb39E/l/3IG0XEIBEWjbSsK5LFRcK0sm/Z/vCuJG4tuZKiuwB1gohVuINkrcBPz9HdV0VSqUSQ0NDhEIhqqqqSCQSC9KOcWEfDocplUqkUinK5TI1NTUEg8EFadMlsOj7dS5g2zY7mmv50XeeZ0eN1ycDA72oioqqqtTUNXD/mo2c3v8CXzt+nJe/8Q0kq5JLScBfU79e9jptl/Kn9pH7+E+QJQdPsHuQroso25ctbyGF7uT2XOpap9t3LWNgtvXOhDkxdEkpbeD9wPeAY8CXpJRH5qKuK0U2m6WzsxMhBO3t7dTW1qKq6kI3C4BgMEhtbS2tra0IIejq6iKbzS50syawmPt1LpHPZYn6dVzpYjiyMk0G23EoGwa9PV0ce+5pGtPd7NLKPPrp/6K3q3vJaIFz2q8SzG+dIPs/nsDNzqChO+51qepCAXg1wvFSZSw1zNn8X0r5KPDoXJV/pcjn84yOjtLQ0EB7e/tCN+eyCAQCtLW1YRgGnZ2d1NTUEA6HF7pZi65f5xpSSnKZLJoiqAv5GCyatMcCE/vHH/5iqcipE0dpyGa4d8M2nv7aV3jgrW+nvrFhSQiIuepX5/AAuT/8Ps5wqWKIYeIvAALkBYupS+WluNhxwy9RG4ZBR0cHPp+P9vb2q/J2WUj4/X7a29vRdZ1z585hGMZCN+mnDoVcjqCqsLImyWDRQjL9gpvjOPT1dtN3aC93hCWPffGLpMZSN7ywklJOa++WI0Vyf/B9zJNjM54rFBUC+lw38acSN6xwl1IyOjpKJpOhtbV10XijXC18Ph9tbW1kMhlGRkZueIGxmFAulfCrCvFQEE3TMJwL770n3DwNXTI0NMjwycPc5LP5zte+huM4C9HshYXlUvqn5yh//1xFUZ9+9iJUFeG/vAFBCHHZz4XHzUUZSwk3pHA3DIPu7m4SiQR1dXWLxqZ+rVBVlbq6OpLJJN3d3cta/DzBKpdRVRXTMlhZFWWw4N13KSWG4+IqOpFIlIyrMWxCxnToHeiHoS4io/0ceGn/T9XLWEqJ9fQ58v/nBaTtIhATol1A5Ze3RWkKIkKX19zHZweX+lx43FyUsZSwaH3urhZDQ0MoijKxKHkjQlVVWltbGRkZAaC2dqbYlGVcKxzbIZNKoaieBh+WJudKNs0RSdpVaapvYnVDLSG/jzWOxLBtRvMFekdHOXSui107a/nBY4+xacvmxej9dN0w2a9bDhXIf+RJnNGSt238GLjIoKWtTCCCU4X7YvOWWaq4YYS7lJKBgQFqamrQNO2GFezjEEJQU1ODbdv09fXR2Nh4w1/zfEJKSTqV5vFvf5uzRw5x+7ZVOFKiKQJVwLkSvGrXVpLh8wLbpyn4NJVowEd7TZLhfIn9p84RjCR5ac8+br/7zhu2jybMUo6k9K97MJ7tqey59PVqrVXgX7wz6wsDtBZbENOlcEOYZRzH4dSpU9TV1aHr+g37AF0IIQS6rlNfX8/JkyexbfvyJy3jspBS0t/bxxPf/Aa3VwfZEvNzvKObQihJSo8Sq6pmx5rVJMNB5IQ9efKYEyAFdZEQt65sgVyab3z5q1jW9QnWWayQUuIcHaTwyb1IazxQaWYIXUHb1QAXUDjMZC5ZxpVhyWvulmVRLBZZs2bNouVrmWuoqsratWvJZrOEQqElv3i8kJBSMjw0xDPf/S6vWFlHLN1Hw/pmT0ytb0W6Lo7tYJkmpmFhGRbS9fxnpvpVe//9qsKDa1opn+rmhZ88y5333nNDKh9CCGTZpvhPz+F05xCI6XyKJn2XKEEf2tbG+WvkAmC2tAdzgSUtDQ3DIJ/PE4vFfmoF+zgURSEej1MoFCiXywvdnCUL0zR58jvf5b4VdcTS/eA4aEJ4ZGFCoKoqfr+PcDRCsjpBsjaB5vdsxtO5SIJAFYLXrG1h39e/TH9//w2niY4LMHtfD6WvHWe2l6dtqUFpS0xb3tV4rCw0/cDl2jzfXjhLViIahkGhUCCRSMztzZLy/Oca4ErvM5fPtRCCRCJBsVhc9qS5CkgpeXHPPtYnglTnh8GxQXgaaK5k8J39xz1myMrxQgh0n494MoaqKRevFp4vGV0I7qmL8PjDD99wwl1KCWWb4r/swR0pTfKNuehIJm6SAP9dbYh4YIZjlx6mMyNd+H0+zUxLUribpkmxWCSZnEP+DinBNKGjA/bv9z7nznnbrgAFG54egS/0eJ9nRqHozJ2QF0KQTCYnCMmWMXuUy2XOHjrI+qBAWMbE2OoZy/BfP97LBz71Vf72209xtHdo4hwBaJpGOBpm5qHo7WgMBykeP0R3hZrgRrInOwf7KT96epbjWqJEdPyvWT+tWf5q7e1zQT+wlLHkhLtt25RKpfnR2E+ehBMnYHDQ+5w44W2bZVCK5cL3B73Pkaz3+W7l9/Vh05ge4xp8oVD46QyguQpIKTl7+izNQR1/IT3l7fuj42f52DefYDRf4nM/3scPj5yacq4QEAj6EYpyCWEkQMLWZJCnf/BDAEaGR26M/rFcSp/ejztS4nKLqOPQtzegbr+x7e0LjSUl3KWUnDlzhmg0OvdvWMOA4eGLtw8NwSy9UkoOHMtNna1L4GQO8nPs2CKEIBaLcfr06RtGO5xrHDlwgLWJwBRzDIBfU6mPR6gKh1GEQiqXv+hcRVHQLpdwQkpaYmG6jh3BMAy++qUvc+zIsaXdP1LidqYoPXxi1rNRoSmEfn4bIhaYdSTpbDGbY69Ei7+w/ku1azbHX8n1XGvU7JIS7gMDA/PnFTPTSHXdWdtUJODIKZZGr4jK9rmGoiisWbOG/v7+ua9sicMyLQa6uqhRXKTrYpYNLMMEKQkFfKxvruVvfuH1vGzr2gm7u8RTOMYzdvkCvoppZubO9SsqIbNEIV8g29PD0489vqSFu5RgPnoCp2/yC+/CEe9tG9+ib6zC/9r105R1cZTolbXl0vbu6b5PV8ZM5S01LBlXyOHhYWpqauaPSsDvh2jU0+AnI5mEWSbTCCjQFoKT+alDvTEAsXm686qqUltby8jIyJwmIVnqKBQLJPwaqnQ40T3EiQKEhcPWmhC3rm5n18o2aqMhHty2jrI/ArpAlovkc3nODaQYMWxCPo16n0bIN0PnCoGQkioNent7CRQzuFmdUrFEOLLwjJ9XhbxB6WvHkBPayoXz1KkQukLo3TsRTTHviBloAqb7vowrw5IQ7obhLW7Na4YiRYENG+DMGcjlvG2RCKxZA7N8wfgUeFUD+IdgsPKOaAzAA7WgzuO6jaZpHg+KYSw5Vsz5gaSQL1CTTDDiarxALZte9SDlYomnfvJ97qdMMh7BtmyCdc0EYlXIzuMMDo3wgzNDFFu30r5zC2nb5tjhfWxI9bMyEZkxjD6owvFDh4ibBRS9ltTY2JIV7vahQaxDQ5c/sEI+4NtRT+Dt2y4KXILLR3VetoZpIjlnivKcbRnj7bnaCNXpzrlw/0y41gjVRS/cpZQMDg7OP1eMEBAOw9q1nvYuJeg6hELnI1RmUUS1D+6v9ezvAHEdEvqsi7guGKcq6OnpoaWl5YbyCLheKJfLhIIBzvQNs+62+1m7rhHTdJDy5fzw2//FvS0mDqDgpzaXore3n0d7CjTd/SZu27KWuvokjitJb17Ps48+QixzhprwdFwyAsewOPLdR1gr8yRpIZ+/2Ia/JCAl5g9O46bH4youNa4kSlQn8qG7EA3ROQvuWcigoemwkG25JuO1EKJDCHFICLFfCLG3sq1KCPGYEOJU5X/yWuoYHR2lubl5YQTSuMfMiy/CSy/Bvn1X5Qr5qU74TJf3+d4ce8rMBCEETU1NjI3NzK390wtBLptFsUySPkFzYwJdVwiFdNZtaOOg5edbh88yli2w57k9PPbMXr7ZZ3HTm99NNt3HZ//zX5C4+P0adfUxdt15M/5LRAlLy6Qm04/lSKLCxV2qHjN5E+MHHqXvzL7tUDmA0EOb8L3mYlv7xFHjNu7xxSpHguWA7Z5fvLoMFpNgX2hcD839finlyKTfHwZ+IKX8KyHEhyu/f/9qCjYMA9d1F5ay17Zh3F/cvXKxLIGSC2blVHMhJHsFqqriOM6yeWYauK6LtC2awxr9qSGqG2oRAiQWHR3H2bhzF03VClWRIH2pHNqOW9m8dSXZsQ5efK4P5Pnp+5nDB9joOsD049a1Hcq2Q51Pp5zLYi/ReATnXArr+LBHvTDjUZ6w9e+oI/xH90Kowv00LoQtF5kq4nRncXszOF0pnK4MsreE61i4joNQFFRNR9QGUFujKG1J1JYESmsMpTYMPnXOpsKX8p2/3LGXO/5K6r6acubCLPMG4L7K908BT3KVwr2vr4+2trbr06plAFBdXU1PT8+SSDU4nwgEg4zaDgFVZazzHC0bNyEQhMNhfvnXfx0nlyWqZEhaBsGAn+c7jmPb93LbPfey89bb0X0eBcHY2Bi5Y4cI1kZmrMuVUF1dR7XukC8UULTFy4p4Kdgv9eKOXZ7qQq0JEv3IgyhrqgGQRRP35Cjmc10YPziLfXIEuzOLLHo8PV4o9zQFjfOzKQIR0FCbI+jtVfjub8d3RzvqtgZEzH9dBf1Vs0KOb5uh3KVgc5fA94UQEvh/UspPAvVSynHfuwGgfroThRDvBd4LTCvA8/k8zc3NN0yijcUCVVVpaGigUCgsipysiwWxWIxzLui6hn+4l8xYikRVFaqqcvvdd/Pko99Baj4U18Yf8NGeGuPQU0+w+e570TSVQj7P6NAQBx//HjsTfk/rl7IiZ6YKAMu2aA1ILKOM6XPQ9SVI9CbB+kkP0paX1NqVmE7sz+5Hf/lqZG8W4/snKX/xCOb+Adzh4gVexeKC/xdUKAEpwAU3b+GeSGGfSFF67AxK1Ie+qZrQL+4g8Ms3LyyNcMnCOjyAUhNGWVE127iu645rFe53SSl7hRB1wGNCiOOTd0opZUXwX4TKi+CTALt3777omNHR0WXtco7g9/sZHBxcFu6TEIvFKLmAqrM55uPgY99iaO1WFE3l3PFj+MslfA0BBKCqGtUhP+LYPs6M9KMmqlBSQwTsMq+uDRLSm7DKBvlcAct0piiSjnQZSaepCUtURaEsIRBagkk8XBfz2OAFG+WUbyKsEfnd29HvXknxr56m+NkD2B2ZCh3wZFzGXj8NxORvUuJmTcyjo4QE8+uKdiEcSemfniP31z9CrY+S/PLbUTYsjAvyNQl3KWVv5f+QEOLrwC3AoBCiUUrZL4RoBGbjJzUF2WyWhoaGa2naMi6Duro68vk8kcjM5oOfJgRDQfK2g6358KsKO8OSzNm9SATdPcPcsXktwi4i8aIEXVcS1RVW1CfxR0Io+EH6JrIN6X4/Il8Cpi6Wdo5m2Ns9yLr1dahAXqrEorEFuOJrg7RcnFPp6fdREey/uBVhSVJv+hz2ufQkX/hrqvmCX97MQYn7iP3Pewn80m64XKTwXMJxsQ8N4IwYyJyF059desJdCBEGFCllrvL9FcCfAQ8D7wL+qvL/m1dadiqVWtba5xiBQICurq5l4V6Bpmn4IlEyDtQg0BRBdSiABDK5POXMGLFwANu2KOTy7O3sYzBdoLljBF8gRMCv0dgQo70uiSqgkMtjmdYU+6jrujxx9AzhQJCSbaMqPgqqj0BwCTIjWg5OtnyBl4z3alOCKoE7mrD29mMcGJpI3HE+zd7lLNKTceljBaAkA8T/4gECv7QLZpFs+0pwpQuq0qcS/JVbcIZLaFtq0XY2eVdwFesAC7mgWg98vVKpBnxOSvldIcQe4EtCiPcAncDPXUmhxWKR+vppzfTLuM6oq6ujVCrd0Lk9ZwshBC0r2jnXfYqakADpIoXAkZKkX+U/Ht/DG7etQpGS4UyeJ17sZK1RRVG3SNYKFNXlxX0dnNoyzP07V1MuGkg59ZnuHU1RTKfY1d5ErjiCpjhoyZolmVxFlm2PGW9KhlQQioIS8VF+rh83Z03Zd13rr5SqrU4Q/8tX4HvTxllr7HPpCy+EQLurncQ3fsEL1FLF/Aa1TMJVC3cp5Vlg+zTbR4GXXW25w8PDy1r7POE3fuM3ePjhh2loaODw4cPjm1UhxGPACqAD+DkpZUp4b/G/B14NFIF3SylfXIBmzwmEEKzftJHvv7iP3WuqEVaJsmWzf7BEU9MOopkafvyDY2QLJQK2xq20ENJ1ErEgQd3L2bs6VMXBFwZ4LtDB+uqp5HambfPjvS+xpb0ZLRSmPzvEWNmifuWqpZlopmyDPY2AlBJnpFwRnnMj1CQejUHg3naif/lytF0tIGYvtK9EsF+1t4xPndi2UBGqi2pU2bZNKBRa6GZMQM70me3YkN4ZwnOCnvg9u+no3OPd7343X/ziFy/c3IgXp7AW+AFenALAq4C1lc97gf87X+2cL9TU1FBUfWRUPxLB0cEMVfHV+PZ1E+vPsTvWzB1VK1gbrqE6HCIZCxKLBDBdB9N1UFRBezDOvue7MOzztnYpJXtPnCY1lmLnulXEQwGEUOgt2qxct24Br/jqIW1n2lE8PsQvHdR0bVBrgsR+/w4Sn/lZtN0tC+aNMo4JAW65ldnM4gimWlT0A/l8nqqqqgWrf7xDSpbLWNkl4yhktTrKsTgOAk2BYFYlFvBoBKp84K+8HoXgvNS3bSiVoFTCXzS4K2OB6+IgiFs6ri+A5fejhkNoFf/ohYjAveeeezh27NiFnOIJvPgEmBqn8Abgv6R3k54TQiTGF87nsclzClVV2XbzLg6cOMydMYVRSyd+coBSOjdhBggGdAIVu64rJSNGkUOZQW5KNpL0BfHrOtqwwnCuSHMyhgB6x9K89Pwe1m/fRiIUIFUsUXQchrUwa9auXWjZdFW42ONlTmsDvEXa4MtXEv7gnWi3tYO+8LqplBIMB/ORYxgPH0dKif9Va/G/cQsyuLDidVEJ93Q6TSKRmNc6xwW6YUvO5V2Opl26TJW8rWBIBam3QXzSCcOVh1yFqAYrw7ApKmn3u6jZNGJwEMbGPD4a2yYgJQ9MrjAL7iCgagifn0IsgdZYj1ZdhVoJZplPQR8MBnGnRt5qM8QpNAPdk47rqWybItwvF7+wmCGEYPtNO/jMs8+xOVmNWXYxBkYQQjBUzjNYzqMJFQFY0sVxHUKaj1urWwirlZc04JcquZKBSELeMHjq6R/j+nS2r1kJCEI+nXPpMsmbb6a6pnrBbLLXBGd8zFxJ26/k2PO2fCWi4bu9hdD7bsb/4FqIzl909eUWVKUrKX9+P5kPfheZNr2I9K8fJzZaJvgbtyLUq38BLcYI1auCYRjU1tbOa51SSmxXcizl8OyYoM9SsCffkhnup8RLlVe0JcNlSW5gjKrSORKF9KyyNCmA4thQsomUCjhD/VjRGGZbO/6GOhRVmVcBr6oqpmletLB3qTiFmXC5+IXFDUkoFGLDrl08e2gv0jZxK0Kszh+myhfEcl2EAE0oaEK5yOZqWjamdPBpGqZt89iPn6fQ18362+4iWWF+1FWN0zmb37r77qUbpDedvf26oKKlawKlIUTgvlUE37EN/fZ2iM0/ZcblbO4yZ1D6zxdx0+c5p9yCTek/XiT4CzuQiek9oZZChOp1Qy6Xm1d7u5SSsZLD9wdcjpc07MnLDxM31ZPvqpSouDgoOEJUrOiSiGtyb/YsNxV6CUh7+rg6IXBQcIVAkRJVTvYwGC/f0/qdI1nKg3Vo69bii4TmVcAXCoVx4W7PEKfQC7ROOqWlsm3JYzzhhmmadJ45h2o6PPfiKXasaKCkgb/CGaMLFV2ZSRhLLNshWyiTDpapjQZ5at9B8scOYja0s31lC2olDZ+uKty/vp2zT3yXbyuCV7721UvOY0ba45r7ZG+ZCjVuUAXDmSYjzbgzpIApFnuJUAUirKHWhPHd0oTvvpXo961CXZkEfRG/AC0Hd6h00WY3byBN57xMkCB7MzhnRlHaEijtSY9GYQ6f8UUj3FOp1Pwkk5BeRpiOlMnDQypD9iT+XSlRBdRrNu0hSavuUB1SCfhUhFCQCEoujJqSgbEia7uOsrI8OvFakICDYNgXJViTJF4Th1AIRdMnAl+KpoWZL+LPZiCdIlDMIaScEPKh4QGMQp78hk1EapOAmPNZu6IopFIpkskkQJrp4xQeBt4vhPgCcCuQWcr2dikljuPQ39fPiUOHGD53hnOHT6A+dZa1BZUau8BPbh1FRptYK4OokzuhEgl/fthITMthNF3gnJVm884afvzSQTL7X6DXH+Vl2zZSFYviuC6nhlKsrElQNExeXRflzE8e57MD/fzMm95IJBIlEgkvDUpmdwbNPaAS/8j9CFXD7hrD6c3gdGWRoyaYLhIXgeIJtlo/6so4anMMbUU1+o56lJXViOrgdfdXnyuImB/fAysxT4xOvK+EAr672hDx81q7s7+PzPu+gXVyDLU5QvwfXod+/+o5bduiuYPV1dXzUo8ETo+ZfGNQJS21iulFogKrAja3VkFbRCGkKwgxjTYlJa2UkEOHoJye0EFcBB3+JM9G2+n0JamJ6LylRlCln89LoAI6EK5OIGUjtmlRHk0hurrwZ8YmhLy/mIfDB8lv2kKkvpq5cgd4+9vfzpNPPsnIyAh33XUXf/ZnfwaeDf3BaeIUHsVzgzyN5wr5S3PSqOuImTwWXNfl1MlT7H/mGUID51ifCBJOFzB+1ElrxrOd5wIOriLoE2OYJZ0WGSXi83t9PUmwSSkpGRa5YpkesjRsDTHc14V55CV61BA7dt/EusY6NFXjaP8wz57tZUNDNW/csZ7vHDzF63ds4GsPf5v/809fpnpVK6//6z9gzYb1S0PAXwQBhoPQFALvv817AdiOt/hqetS90pUIRYCqgE9F+BTQVFAvrcUulPfJZW3uukr4Q3fhDuQxnukCJP47W4n84X3gVz2Tiispf/0Yxt5BBGBnU5Q/exD97pWXnJXcEDZ313XRdX3O65FS0pV3+eaQRlqq4xuJKi4PVDlsq9bw68rMolRKj8/9yBFEOn1+u67T17iKb9DCmKuBEHSV4Ft98JYWCE/DSCqEQPf70BrrcGqqKPX2o589g24ZCCBgllGOHcHybUdPxufkYf/85z8/8T2Xy6FpGr/6q7/qSCkvilOoeMn85nVvxFVi3JRSKBTI5/OUSmV0XSeZTGDbDr09PRRyeRzHJp1K4boudQ0NRKJRnnzscRoUl1c0xUjEmugaTnPsG0doSykoCLrVMk27ktQ317OmOkpPbIThksXJ02P4i4KgoqMIz8RSci2GzQx2laCtPUTv8ZcI9HfRp4ZYe9MOtrU0EA1HsByXFzp6uX99O0II6mMRZNHim//xJDXDZXwu2OdG+dIv/A67/+DXuPvVDxIMBpeYkJdIF8rfOUXgPTdDSPccB/zTC6eZBPZcC/LrGcQkhEBZkST+qbfgnPO0d3VlFUR8U65ZifgQqkA6HpmciPrmfCF90Qj3uV5YklKSseDbg4KUUzGmS0mtavOGRkl7XEe53M2WEs6ehdHR89v8fsTGjTTV1fHKnMIjA5CzvV2nC/D0CLyyfiZm70pEm09HXdFKKRzBPXoEf7mAAHSjhHP8GPKmHYhAYE4Hg6qqGBfmi12EkFJSLpU58NJLHNyzF7tUpDaZIKgKjI7T7OkZIVrfwIaVbdRGwyTjUdqSCYRrk+o5y/MHDjHaP8Dr7tpOsJihc2iMr37jRTb0CVQ0BikzslrllVtW82R/hrX1K+gfGmFULaGvE5Rf2ktS9VHMFSjaLiNGmYA0wI4w2mfgNw1O+uNs2bkDVdMJhSKoqkJ3KsX6+mpW1STpT2V56olDRA4NEbYkacWlW3URIR2RS/GF3/ljjrx0gPf/8YcXry1eFRfS5kzAfK4P+9AA2q2t0x9wFZjtS262fOtXyst+2TojPrStjTPsh8A7tmPu78V4sgt9Zz3B990y5wRni0a4z/ViqiPhyWFJr1EJB5aSasXmLY0uzXHf5TtUSk+o905aQ9Q0L89qfT2qEGyKeSaab/RB2fW+70vB2gisCV9aNgshCNYmKWzdhjx4gIBR9Ozw2QzumbPITRvnVIsLhUKkJ89GFhmklNi2zf4XX+LZbz3MppjOm+68h1hNLYplkjm0jyeKBW6/ZRcP3LaLUH4MkRpE2KMwlgLHoVHarNvUyEhLjO++cICYotB1dpjQOYMQYSxcToVNfuauHcTDYaL+Iq5hsHNFE/tPd/HingP88vomktKgfKITRxccdCR5W+KUMvRKnXLTWl61a6u3YF+2iYeDBMMBhs4V2NpUx6Gzfbz03YPE+71FuC7VphjWWLVrNbfvWkMyHOBY3wjf2vscL+3dx65bbkZV1Vn3fXd3N+985zsZHBxECMF73/tefvu3fxuuc+SxuIRwdzJlSp9+kehNTV4ijeuAq8l/epEJ5TqUMWPbJMixIqgKIhGYyicjBKI5RvxfHsIZKqBUBxGxwJzHNywK4e7McZoxKeFcAQ5kBOMUoUEcXltj0Ryf5dTXcaCjwwtQAq/j2tuhvn6iExUBm2IwUIanRjzhXnbhxyPQHgLfZaoRQhCuipFevxHlyEF8juURI/X3QUM9VM+tT/To5BnJIoKUktRYiq98+tNE+8/yi5tXEl2zGYJ+xEAHzsgA53oH2HLfA6xNBFG7j4FlVCIlK2si/iBmIIrlgD9X4lUbVvDNF0+QPjjGXTKJQFDGoW17PS1VMUq2zaaN64hpDvlymVft2sSW+iQ/fOFFWspZ1klByYG8C/3CxxER4ead23jHzs0oCL667wiv3r6eUDgAisJwJsfAuREyP+mguuR5mnToLv7NDUQaorz+jm3U1iWxDItdfp1NLbUc/PaX+bcf/5g7X/UqNmzc4M1uxaVjPzVN4+Mf/zg7d+4kl8uxa9cuHnzwQfAij784TYa0yZHHt+JFHt962U7RFZgp46SE0leOEXzHTWi3L61Yh6uF9UwHuQ9+FxHzEf+n16Osq5lKqSYERPxokflz51z4EC+Yc24NW0qeGwNTnr/dt4UN1lQHZifYpfQCkyZrttEotLXBBW1XBdxWBQ2T3Fs7i97LZTZmPiEEsYYa8o3np7TCcZCdXcirSPN3JQgEFh87oZSSk8dP8s9//hFuccb4uV3rSYRDiMwo6plDKEPdKPFqtmzdyHo3gzrUBWbZS9ojKmQP4Shu0yp88STBcAhXSk72DTN2cIib3Tg6ChJJZ8CkoT1J0bJI1Nawbds2dEWQK5lEEwnikQj333wTP3Dj/KNs5j9o4KlIG/W33c09d97GLz5wG+FggJe6B9m5ooX6ZIxILErn4BiHnz1L6YmzJIteHw4HBCsf3MAvvuF2FFVydjiFbdpEYhGS1QmiQT+31Ma4w0nxyCc+xv/+X3/LyMjIZQdRY2MjO3fuBCAajbJx40Z6vdlmgqmRx2+sfJ+IPJZSPgckKi6wl8T54JyKwjTpu0DgDpUp/NXTyPTFboITZQgx5TPT9un2Tf49U5mXqnc2mPVMWYLxlaMY+/oxftSF9cTZ2Z03x1gUmvtc5/McLENHsfJDSmqExe46HWW20WNSwsDA+QAlIaClBWawh0Y02J2Eb/d7ybAtCYeysCYys+19MlRF4G9vpTg8QKhinhGpMcjnIR6/7PlXi7Vr185Z2VcDKSV7nt/Dw//2SX79lvU0JSIgJa5lkuvrRtN1wpEIilkmUEgjxmkYJz+UQiCFQOs6jmUY7DvTw+mi5NDBfm4f8BFBBSSD0kC9pYXWbVs529lF4VQn61JpqoQglUlj+IJkbYt4JMKbdm6kL1PEr0IyEqZkO2xbtwJd13nq8BliAR+bmmoJxyIc7Rrku599ls19LrhefMRQVGX9a7dy28YVCAFVAT/fP3qWja31hKNhdJ9OojpJIZenVgrevX01+/p6+Ls//mN+7fc/TGtb66wET0dHBy+99BK33norXGPksXcrz0cft4Yv7bYskZS+dwb9n18g9KG7L+kVcmGg0CXLvTCI6BK/Zypvtoup4zlxLwsB/tesw3jiDCLsR79zxeRCJh03v4vji0Jzn2ucynvmkXFsDlnEQ1fgnWOanuY+Dr8famtn7CwhYEPEE/LjOFeAoj37KkORAKXaSQlLbBs5MjLzCTcYpJR0nOvgP/7xH/ilWzdNCHbLtOjsGeBY7yC6roJjISYL9osKcnHTY+QyWYqBKO07dnLrlrVs6nOIo2FLh6JjcEIvcc/NbWwMwcs3tnHf+naO9g3xjZeO8vTRs3QYgnA0Rs522LG2nWgowK5VrbTWVuOPRmiuTnC4o490Ps/Gxlo0XeV41zCP/euPaR2QhBQdB8lIVGXbG2+itSHJWC6PdCXJkI8fHD/HmcHRCYGiqArReJRQJAiOw+7GGh5qifHvn/g7ctncZe9fPp/nzW9+M5/4xCeIxaYmA6l4Pl2xu4iU8pNSyt1Syt01kWRFX5++KIFAmi75v3sW8+GjSOfiWedMjInj2yd/FgoX1j9duwSgv2w1Vd99N8lvvgNlS513rOlgvdBD6fMHsQ72e2RrV3A9k4+9mntxwwt3R0JH4fxvHZcNCe0KplwScjlPwI8jkfAE/CUQ0aB10hpxwYb+8uxMMwCKEPjra7HFpC4aS825aWaxwDRNPvupT/HOl93JqkQIpMQ0TAYGR+kvlLlpbTs+TTtvFLiABsALUnLJprMMDgwzZrpEVagvjXHgu89RP2x7tvxymgw2+sooa5pqQEoc2yEW0Hnoli3csnU9ZzMlyoZBvK4BRREkkgnu2bwaNxjg8FiO29a1Mzw8xtf2HGZbUy2KIjh0doB9//USa7N+woqPvF1i0C9pf+VG6uviPHuun8+8cIjvHTpByTQJqCrZfJlS0aPLFZUoqXA0hKZruI5LSyjILt3iG1/68iXXqSzL4s1vfjPveMc7eOihh8Y32+PmlusReSwC2jTEXRfyp4IzXCLzoe9iff8k0nEXBVvidYcQCFVBNEYRtZXUla6k/O/7GHvdZ0i/++uMvf4zmI8cv4pX6tXjhhfuRVuSsWHcLhgXDsnAFV52LgeThWosdtkpliqgOXDeGmlJGLxCT0M1FMT0eXZwAVAuIS3rkufcCJBSsm/PXuJCsru9AVwX13VJjWU5PZZl++pW/BXBPt25hmHiui65TI6xdJ6+fJnGeAjFLNE1kqa4dxC/VEiV07jSpV+x2X7TCvzjyR6kJJ/Lk89kWR0P8dGfe5DHH3+C7oEhnj/VhWHbHBpJ889PvsSoJfjWgQ4+v+c4J4bSHOgd4ht7jnHy4dOsyGr4URgrpxhWHAabQgzh0l0yed2d23n/a+9l25oVnM3btKxcSW+4mkfPDHG0fwSnQnKhKArBcNBbP3AlOxtq6HjqcZ595tkZtd73vOc9bNy4kQ9+8IOTd6XxIo7h4sjjdwoPtzHbyOOAitCVWckquyNH+je+hfH1w2AtLQF/ufWA6Y4VQiDHihT/fS/OcMlLSdiVp/C/nwPDviKb//ixs1lLuBCXtbkLIf4deC0wJKXcUtlWBXyRJZDQoWy5lCwAFaQk4lcI6ldo+ypMUv2FgEjkssJdCKj1ex404xQbI8Z5Zo3ZQPP7kAE/smJ3d0wLTBtljtcoFhqmafKdbz7CL77yPlQjDUCpUKJzJEVDXRVhv29GwZ7O5OhJZVlRnSSbLbCnZ5AHd23Cp6lIKXlxzxlqs4KCVSRn5oiGqsiGXXZsbGWc6kHVNaKxKOVymexYloiE165p4is/fIZjI2kcnx+/rvLrr76H1roaUATlfI533HsTB871c+RzB9lhhHGly3BphFOqQXlrPW/7mVvYsaaNIA65dJZ0psjBoQz3vekhPrR+NbpjUlJ0nj9wlBOHjrOruZqGRJRAKECpUMK2bFTgZ1Y38S//+I+s37Ce2rqpZHvPPPMMn/70p9m6dSs7duwA4C//8i/hekce6ypKVQC3mGfqgur0sDtyZN73CJGjowTffyskz3upXSoBxuS+vV64nkFMM9YhmWDOFBUuKkrOvGrus1lQ/U/gH4D/mrTtw3gJHa6PW9UcwpZgeykcAQhqAvUKaDillJglg3FxKoXwApdmcW5Uk+PJxwDIGXaF6GB24l1XBbZ2vouk606dQdyAkFJy6MBBypkxWhtq4Ww/lmVRyBXoz5fYvGHl9IIdSblkcLxrgOrqBMV8gQN9Q2xb00oi5PkUD+dLjOztpcEwGCunURWVgiqoWVNFXW01UvcjXRthGoAkEAhQ8pUpFsscHUpRvWEjH9m0kppCCqtsoZYLWKMOqqYSUBQsVeXYD06x1fA8coaLo5wRJapes5lfffvrCDatgHyG3LGDlAoGz/aNctsdN7M+rqCcOwyOTdjn575NKznd2sQ/f+mrGJk0axrqUBwXx4Wg4tIU1Kkt5/iX//v/+L0//P0p0d133XXXTILrukYeC01BW1uF3ZOf7Rk4Y2Wyf/EU1vPdhH/vTrTb2haEQ2ZeZg5VIYJv24Z16ilk0UaN+An+yk4IzN/1XrYmKeXTQogVF2x+A3Bf5funWMwJHS7oSIVZroBPgm3ZjBsBpFBwFY3ZxA0GcdGkwK20oWw5INVZq+5CCNxJrpZLaDZ71XBdl69++atsX78OvZRHmAZGyaBsOai6RkifOmQleHZy1yWfLzBUMljj0+gdThGOhFjfUDPh637wWDeye4QRyyKg+qkOVnNYKXLrzpXoroMU4DasAEXl5PPP4DNKxP0+Hj54kp133c5D61YhhnqQWhQ36lIulbEMG1VVUTSdbz76Au2dLqrQGCmPMeQWiL58Hb/6rp8j0L4WbAv7zBFsyyJdKlNdX8cG3Ubk0zCeu8gso/acZs3KzfzJh36Hkml5i8LFAm5qhEIux6DhkLR8fPc736OhoY77X/EgK1asmF+qAkVBX1+H8WT3NNroZKbI8xCANF2Kj57GeKGHwOvXEXrnTrQdTRDxISsLKFd7HZfynLmSRcwLf19Ve1RB8DdvR91Ui3NiBP2mZrQ72ubVYeZqXyP119Otai6TOmjIKRdpVThBZtthEsH+5EoGdM/WrSiCOxU/dbM4N2YVeW2qc4JoKpiMImifddullGju+YUzRygIceMuk0gpKRaKnDh8jFsbEpROH8bvWNiW52UQ0NTKFPc8bMtCCEGxZFAqG8RDAWzD4oWzPbzh7l2eKyTQn85x7PtHCVk2AdVHXbgOW0AxrrJhdSNCulDMofacxGnfRMOadXz1K99ga0M1fl1jrShj9Jz1Iql1H6ptofvOa8zPHe/C/nE/CREibxVImVm610T50Pt+gUD7GqQQiLFBVKuMEAo502b3qnoU150w8UkqAXeZElWlMlFriKhRwhgeID8wgGNa+IA2RfCOdQ3E1J2sq07w6Oc/z833P8DuW2+Zv3ysAvR72uFfX5w6NZ4lnJEyhX8/SOlrx/FtbyDwitXot7SgrK9FiQXAr3rkYtcqDK/EDnqJIq4KPgXfK9fBK9ZNtGE6r6HZQXg23omg18tf1DXPEa4moUPlvHlJ6hAQLgEgDyCgZIPpSPzarNVnBuP1vFhpoSpgg8OshLuvXOSmQu95lbvqyvI9urYzZQHV1nSEuihCE647pJSMDA/zxc98lp975T20iTKHjp/BtW1G8iVwXTIlg73HztBUHaeuKuEtmqazhKNhDnb0UeXXwXHpH0ujaAo1Ec9dKW9YfOfre4l0pAn7wiT8cTRFJSUNmjfUk4wEgYot1nFQek4RdT3e/Z90DVJT38DToxbbNq2mraURYVtQzCEKGZRSntFckWe+eZAddhAbh2Ezw5m4wpve92aqV64BoQASYRRRVM/2v7qhimTQf/6hB1zH5XBHL1Y4xorBsyiOjWma5EYyuO4khUSCYhqsUUyG+/t53ZbVfPWRhwmEgmzdtm3eNHhtSwNqTRB7oDCNjj4dLtwucdMm5ae6MH7cjQiqKMkg2poESlUQQhVtfhkIIVAjQfTbmvDduwqa45eVJVcrKQaXSkKHkCaIaQ4jtucHnTUdCraYtalP4C2MjsOVMGzChhncqicgpbcQO3maFw5fUdtdw0SWDTTGQ+gDU7TFGwHjnDE/+dEznD2wn9fctIUWSvQcO0ykuQ5fwEdQ13Esi3y2gGXaFPMlekoGg7kiIyWDldVx8oUSfgGpbJ5Bo0xtJITrODjAo997Cd/eIWr8Vfg1vyf8pBdgtn59E6oytSOLo6MMjWYwUXnt297CytVrEMUsykAX4twRGJ9NSbCly8Pf28+aPihLm7xT5rQosul1t3LzHbdPimAWyGgVytgQuq7hD/qnauyuy+nufs6MpHnNiiZUx/YyfuVLUwX7+H1DkvBrHDpymNaRDnbH43zlM59j1R+vJhyeH054dUUCbWMN9sC4w8GldDRxif0C6YDM27j5HHb39H78822VXGzvFQHwLwr6hioiH7ob/89tveTxVyvcH2aJJHRQdI1WUeQsnkthzlUZNiRVVxBpX+cHXXjujBLoLXkeMJdU/l0XMplJDVE8L5srgCjkUc3z/pO5cJwm7cYxy0gpGRwY5Kuf/wItAY23b18No53sP3Eaf7KKtqo4qut6dECaiqqqpIZThH0+enJ5mnfcxOaWFYj+c0TCnZzqHiRTKJEu5Nkci1EslXn+WC/OUwM0qlHUC7IoyYBCW1v1xEMsgXKpzOmeIXKaztvf9Q5isTgMdqEO94Az1Y1NCnj+WBfOTwaJEWDIyTNk5ym1x3ndz9yDEoqMX6hXR7waN5YkaBqo6iRXTinJ5QqcGBzlFTs24q8wpDq2jWVM7/oqXXAdGy09jBWR+E2DhKXyg8ce5/VvfMP16qJLI+zD/4rVGE91ImdK3nFFmH6p/FJ7L13W9XkdeCWNu0bIKa2azPQjx1METlPG9KsQM7Vz8og8v1cCmC7mwRHSv/4IsVT5kpd4WUkhhPg88CywXgjRU3Gl+is8t6pTwMsrv8FzqzqL51b1L8BvXK78uYZQFNaEXDTp2bpcAYfT7sQi52XPF9AYgNCk12BXEfKX4zozzalcND7frPzjxyFdF6d/YGIw2Sg4VdVzzRI6b5BScvDAQf7uLz/KnS01vKIxjOw5xXP7DhBPxNm4+xaEqiGF99AIQNc1fAEfjutysG+U6pZ2gjiErSKtdVVURYIc7htmrFAi6NM51TnAuUdOoBsOyjRrFfmYQqJikgHPj7yjf5izmRy3r20hOdSJeuol1IFOcJypgh0YzhV56hv7WWkHKLsmpnQZcEts3L2aRDKJFIo3cTPLSOmCoiJjVWjhKEolGbrEW0Q+2TPIquZ6wn59Yrtt2biuO60WbtkWruuwpSFZGVOSB+++g8ce/Q75XH5+PEIE+O5fhZjQlMQlPhecOGtRfSXHLjbMdP2XO+dyRwjcgkX+r3+ELM7E3jYL4S6lfLuUslFKqUspW6SU/yalHJVSvkxKuVZK+XIp5VjlWCml/E0p5Wop5VYp5d4ruKo5Q2PcTz1l74eEk0WFodLsB39Yg1WTok3zNpzIXcJ7RUoYGpoa1VpdDVeQkMTJ5VFHz9MNpANRolWxS5yxdCClZP+L+/nff/lR3rZ1FatKoyiqSv9wilODo6xsboRYFe6qLbjJOkB491oIwpEQQhEMZbLkUmMIywDpIhSFjW0NvHb7WnqzRXIlg+d+eBLGCljKBQtQEnJYlBMaft/5t7Zpmjxx9Cy7VjajCoFwbS87lrjgnSzBcV0+950XWD+oogJpqwC4jGoOW9e2eh4wjo0o5RFdJ8GqjAXHwW1dB6pWoYqVZLN50qbNusbaKY+2ZdrTjjEpJdmCR10Q0CszAKHQ2txEfTTMT575yfXpqFlA3VSHb0f95Q9c4piNiJ7v15DTn8cdLsy4f1HM8ec6SUQgHGCHvzTBP5J3Bc+MSKxZTiUVYGvcM82AZ6vdk/KE/LQwDOjpOS/9VRUaGmavtTsObkcHqmUiKvWla5uIB+d2MfX06dNzWj5UFk5HRviHj/8t77llE6s1i1D7alwpsE2bgmFhWTYgkKEosnkNMhRlfGI83mOZfImhjrNQyE1sdFzJuvpa1jfW84P9Z9BOpUhjU6cEJzXAmwmck0XKcRWtYhOXQCpXwLAdqiNBXMfBdd1pZ71SwHMnuzGeH6IaHy6SQTtPt5PHDuk0JaOeYC/mEKcPohhF7+WSGUGU8shwDBnwtAXbdugZSlGdjKFPjr+QEtu6OOm6lJJiuUSxVJowA3g7XIR0ue+2mzl68PC8RYGKsJ/gQ5s9fvd5t4pfLa5cBJ8nVLi2Y67XK0BUFB6ZvwbNfT7gznFgjlAUttT6qZMV+lEJh3KCw2POrMwzQsDKMLRN0t4Hy/B8apoE764LXV0eg+M4EglIJmcl3KWUmH0DqIMDE9vS/gixlvqpSZrnAKXSzPSs1xM/+N7j3NGYZHMiSGj1RoglsceGCWgaubJFUfeomIVlerzslfHhui5GySBdKNFaX8WamA8lM+LZPSvCUBHwwPoV5Lsy5I0SzWoE9YI+snA5LfMoFW50KSXSdcnli+xsa8QolSnmCzPyt+TLJj969DA77ejEc+oAKacMUT/doxlKpTLmuROY+QwgEcM9qJ3HEMWc57de1QiKgmkYjBZKtNUkJ8qXUlIqljDKFyg9UmJaFqlsBldONde4tk2mu5PV7a0M9PZgzlNWLSEEvp9Zh9o+Pqu8kF9mOpE3OzE49dhLmXxmMgNNfl6m2zfbcq4nruTaZ1GaObN9eFEId02bY/c+IYjGw9wRMVCl51dsIfjeiMK5nDMrLUcXcHcNjNPSuMCzo3AkOykRvJQwOOgJ9/EyNQ1WrvS098tASok1OoZ26iSK6yIAG0G+eQU1Mf+cB0DMR5Jyy7I4uncP97RUE6qpgboWRD6Da5mMFctsaG8kVlWFGOhAPbkP9dR+3EKWgeExOnsG6Bkc5ZmzPbxu1yYCqoJ0HVzpcc/YFTNGXTREpMrHmOYSl1P94r2pkIt0HfKjnqbu2A6p0TQn+0e4af0KkjVVROIxNF2f8nhLwJGSp350nA1dEg2B5VgIBLpQcZEEw36E6zIwNELnqVNofj84NsroAI7jcLR7wKs/UYMMxXAdl+pYmHjQP/GisW2HfLYwYYryKpeYts1IegzLvpifRErJ4MF9OGPDFPNZ0ukM8wIBSkuc0Bs3zvH4nOmlcamXibyG86+HEJ6mHIEnRBQxQ+mzqXP2FocFhxCCYrF4+QOvrRK2NoZZp49TMwpyjuDrfYKzGfuyGrwQsCoMu5Ln3+dlFx4dgKNZzwbL4CAcPz41W1NLC1RVXVZrl67EGB5FHDqMYhoTJohMso6a9gYukbb7uqBYLM55qkMA0zApDQ0SUBWUqgZwHWR6hI6hMfoc+Jndm9AyIyhDPWAaSNvCNi1s2+HccJpv7D9BvmzS0zfEgZOdnOnoY7B/hLHhFLbtLXoqgBPV8bsQUKamUBwPYPNJsPrzdPcMkBpJcaZ/lOqaJNFIaEKjv1Cwl0ybJ584iv39XhJSBwQFu8SwU8InVAzhsXkOj6bZd7KTc5kCqqJUXFtsTMvmcGef92gqGm6iFtd1qI6G0SatlBdyBRxnkmYuJZZjM5JOYdrTe88IIbDLJUb37yEAZOYzZaKmEHj7dpTq4OWP/SmHtr2Wqs++Bf/PbZi1mfZSEJegM1gUwl1RlDlPtSeEwOfXebBRpVodr0uQshW+1KewZ9CkfBnGOgW4p8bLhzqOnCX5fq9F//EO5JEjnr19HNXVsGrVJTtRSoltWhQ7ulEPHUQzShNCxQiE8K1fS9CnzrnW7jjOvGRiKhQLDI2NEohFkT4f9skDvHTwCKPhJPc9cC8RXYdiDsswMAyTTCpD7+AY/fkikXiUV9+6lZs3r8b2+Tg2luGbR87wD0/u5St7j9KfzmLbNpl8jgCSaqlf5CUjpaTPKZBAJ1yEw8f7sCyHU0OjrG68OAHFuLbeMZji65/5CYWHO4ibysSsPaD6OW6NUsTBEBLXMDnRN8wTx89R7dfJZ/NIx/OhzWTz5EslhDFuHnRxXMnJwTHPfor38jNKxoRyJqXEsCyGxkYxLBPkpaMTnVyGiG2RTmfmlX1R3VpP8LXrK2270CwynbfMbLE4PGWuzUhz3mFSv70Z32s3EHz9BoT/WsSvBAEiOjOJ4KIId1QUBWseqGyFENRFfby63uabgw5ZV60ssCo8MurjWM7i1ipoi6qEdGUaSk8Iq/C6Jvhqj2Qkb9FupLg930mjkWKKX2oigdi0yfOQmYHlzjYszLEUoquLYGbM88yo7Ld8fuSGDUTi8xOQYlkWkSv0w79SSCnJpDMkqquJtK/B6DzD03sPEN+whTvvuANtsNPTchGUS2VKhTKqptDSWMMq//RsPq6UjOSLPHX0LF/Yf4z1iTBrq2OUDBsfysRjNTnbj3Rt4qoP4Soce6YTXXNJF/LotoNlmiiKgqKqWK5L93CaF587w/AL/QTzLnUiOOUp1xQVxbE5JyxymsSyHXKOyxvv3Ik/HKRvKEW9K4knohSKJfyKgtJ3FndVGCG9rFu5UtmLm0BSLpanBC05rstoJoVZeT6EEBi2g0DguzDmQQik65AdGaJUnp/1kwn4VILv3U3pkZM4I8VJ4mymsXslC7BLabH20jC+coKM8XWsfQNQdriWV0ZpdRLpm3m2vSiEO3jJmauqquahJsH6pMabhc23ByVDtifgXeCUoXN2AOqGbVpDkmafQ1VIJehTPdc4KakqZ6kq5Pm5XIbyaIoaM4/KeaHsAmcDNZys20STGaQWSaNbQMHzXbcMCyNfRM9lkek0wVJ+ilCXgBWK4GzYSKC2as70lu7ubt75zncyODiIEIKHHnqIj3zkIwCqEOIx5ojOebC/n3vuuB3VKtN59hxDip/777gDRdORiVpIjyLMEpF4FBSVzr4hHEcSiYXx+X0oqjKR9EECSKjy+3jz7s38zPZ1fOfF4zx87DTdY3nWOWC6Jn7Vj1uJc1AVlRY9zkFjkIg/SkMuwMj3B+hrdjjS1E0g4MOyHcYyJbpOjJI+N4bIm1QLHw1qpEIgV1ngk5B2y6QSGtU3reIVN29jw+ZNNNZWEwxHEINdHHvpJT7/zEu89fbtGCWDzoFh3EIOkR4Cx/JIx5AYto2qaRVPIQ9SSvLFAmaFP2d8W2+mQFMsxEUTbymREtLFMso8p3QD0HY2EXr7ZnL/uLcS1LQ4tO65wHRXdon5+cR+d7hE6d8PXzLgaTblDjdGOPd7D6D+v8/OeN6iEe5VVVXzYvf1xrxgdULjF/wOjw9YHCtpWCggBA7Qb2v0Z0EIFUYr5wF+6fDfBl4iZpdJXFCuBMpCY1+4hadjKymUfIheQdwx+G8Dz+GXnilIl5LJ3u6TO85RFMrV9ejr1hCIhOZUY9c0jY9//OPs3LmTwcFB7rzzTt7+9rcDNAJfnAs6ZyklPec6uH39ahjtYF9nHzsfeDmaVgncCcVwmleh9pxC2BbRaIhwPMKpwVHaLRufpqKoAtc5L9gBEJ4GrCgK969soiXo57O5lxgeSNFglfFV7O4ZM09MD6MJjXVqghdLw+QCMbaYCRIdDs91HcFVABdM28KyTRJSoV2No6s6hnSwhEsUDaTkhCjQty3Ar7zr11i9eTNqKIYcd62UEoRCcyJGYyzCU4fPsLm+CiyTgdEUzfExpC+AputENJ2+sSyr65KVoCXvslwpKZRKU4juUiWDkmXj16ZfoHeBdNnyImvnGz6V4PtupvToSewz87SgO0+YNNSm/T3Ttun3ySt67U2es7iqYN/mRj79C7fz+2/ciPjkzOctGuEeiUSw7StIMnqNEEJQFVR5qE3hRNrm2THoNTUsoUyYUS5ca3cl09oxpaoyFk7yneBKTuhJ3IqFbvwcKsEqM3W6o6iYkTiyvY1AfS2KerFJ6HqjsbGRxsbzSe43btxIb28vQAKPxhmuM51zIV8gMzRE46paXMug4Li0N53PEyuEQMZrcHwByI6hlIusCMWIRiKc6ujGNCwUAX5NozkRQ9dU717hCcJUocRAJk/JtHjwpnV01I/ywgtdbC461OlR0orLSGmQFn8VIT3ITmo5aIzwBV+WFjVCyFEwHUmd1NFcHRQNE0mHLKDY0KyEiAg/SDhBgf7dUT7wW79ErHUVQqmwjY7nvCwVGDl3hpFMkRUrWlEtEwWXdXVJ9p/qoiocJpiIoygK9bEwnX1DrK5NMHnUGaaBZZ/X2i3H5cRgiu3NNdOODyEEZUfiBILUN9TPLwVwpX51Qx2RX7uFzB/8AHkRW+SNq8nPJcbvWjbu50sPbuaf7tvCz+6sYXv1pYMiF41w9/v99Pf3E75Ccq1rgRACTYXN1Tpr4y5dOZujGZdOUyNnQ1kquNNR7ArhuTj6/d6iaV0d8XiCO8oKiZzgbAHv/BnWiF0Elqoh/H5K8SR6Qz2+qgRqRRub74fy4MGDHDhwgFtvvRVAuxY655monKWUnDl1ii1tjeiZYcoIXMfxQvtDYYjEYTyNWDCCDHjEXzg2yYZ2bm5dgTncTymbwbBsQn4/kUgQRVUrLoQQcxy0WISTAyOkigZVjVXkbxd8de9p1qfT3KTW0O/TOVUapF4JURVIcLPaxFpM0kiKrgWuzbAsozouMaFTr4RIaFF0oU7YkQ1cnqsu8RfvfhextlXedqOEMtoPZhk0HTs1iqXotN33CoLhEEr3SayRQY70DtE3mqZ/YJhaw8Dn9xEL+Mj3D5MrGZU6vBywk7V2KSVHB8doikcITUMeJ6VEU1WO9KbYceedF2VomktMSUOnCALv2onxnZOUftjJeR/1xWQ1v742fHmJsi5fy6XPFYCjCg5tbuDvX7eLJ1Y10BDR+bUNkYtT2F6ARSPcARKJBI7joM7CJ/x6YXxg+nWVNUmFNUkwLIdU2SXtCn4w7NJvVu6iosC69RDUIBCAUAgqwkUTgpVhL9jJcCFlQcaCcgG0QSb60IlGcVevwfYH0UNBYpXw9/kW6OMYGhriQx/6EJ/4xCeIxabSG1wNnfNMVM6WZfHC0z/irVvbEal+hKLQlcrRe/osLUYZfdUGiCaRpQJkxpD5tBfE5LooikDVNILhECFd8SS5EBfpgaqq0F6TpLW9DekPIV0Xs1ig64EB9h47y6mDnQR7FYbyDuVcDrtoUx+upVYJUyMlriKRwvNLFppAEZUF2Qvm3udkgZc9sJX6VevAcSA9jDLUU/GC8S5Z0wPU774DpZxH6elFFDK4jkPR8rySOkfT9KVztFfH8asaq2qSjKWyRCqLpI7jUDbK41XSnc4jELQlL170Hn8BWCj8ZDDLH/7BW+f1GZq8WI0QiJoQ4f/vPqwjX8YenOzifCnDxXxi8bxmpsPEy0JAf0OET79sC5+/fR2DwQC6Au9fH2FdXL2szFhUwj0SiTA2NkZt7fxpHZMxfrMCPo1GH9RJyQsZ6B+P8FUENDV6d23aabH3P6BCowoNfsBzh56AEgig1NWiz1dShUvAsize+ta38gu/8As89NBD45vt603nLKWks6MTJzNGpBADKfFrKhtaGvi3H73Ie+50qcpkQNVxTQPXPu+SKhSBogiPNMzvQ/NpaJqGoiheAoyLanNRClkol3DDcfyNbaxdtYk1t92LWcgy1NtLx5lzHDl4is5T/fSOZqi3QiSlRhAVrSLQ3cojdlH5Anp9Fr9002aEY6OcOYgo5T2zmxgPTBGI6nrU4W6UzAjSdSmVyvQNjnFkYJSfvW0ra+urGUxn2X+2m7ZElEQ4jGI7uEKAFJRNA6dCGpYpmxRMm80NVdObYxBomsa3jnZRv2ET69avWzBlAbznSL9rBZHfuJXMXzxdiaIU11lfXjyY8Mia5uoutNFPd/ZFewWMJYN89+61/OfdGzleFcOpHHdbTYB3rQvPikBwUQl3TdPmLQR+dpjBP3eWz810z9dC6yzjkFLynve8h1WrVvF7v/d7k3elmQM65wMvvsSq+mp6BoYI+zSqklX87B3bKZcN/vGJF3jt5lU0xiKULIuCYZAuGpRsB13TiIXDaJpKQNfwVf4n4hEaqhOoqurRV1RMOpX1crAtlMww5EaRoShudSP+ZC2tNY20bN3Jna/MUx4ZYLi3h47OPjrO9TPWlUL2F0jkBcOOgU8obCeGPskrxZGSfLVGQ10tSn+HRycwxbcbUFREPgP5NOVSmXyuyLnBUY4Np3jXy29lTZ0npFeGg1TFojy29xA1+TxtNTX4NA3XdckXCxPz8qCusa42cRHvPHgCRVNVurNlvnf0HO/5mTfMq9Y+E4SmEPjNWzBf7KX48KnrKNWnW9K8sPDLPWWzfc1UTGQT9V3p0zvdcuvMcBVIVwd5fNdKPnPXRg42VmGO97mU1PpV/r8dMWoDYn4yMV1v1NTUUC6X5yWg5qcZzzzzDJ/+9KfZsmULO3bsAOAv//IvwbOhP1ihdu4Efq5yyqN4bpCn8Vwhf+lK6uvq7uLlLTUMdQ0S9fuoamrFV93Au14V5Mk9B/mvp/di2w6jxRIhXePedW1sX9FMW3MD0fpGlGAIoWqoApxinuLoKNlCiWgogOM4FPIlimWTeDSIz++f0O6F6yLyGdRCFukLQiCI9AXAFySUrKa9uo72bTu5x7EwiwVGBgc5cfwkxR8epepkmSfECK1uAL9QacBPCZdwXRjdNhGGx8hnmxaqpiKEt7grXQc3M0oukyedzXN6KIWuq7zp9u1EQwGk7scNx1BSw8SjIe7evJbH9x9FFaPUxWOUTZNMsUS2bFKyHfKG7b0QQ34ivnEWSIFEogqFklQ4MJji5nUrWLt+3bUOjavCRcJGCERViMhHXo59egzryMj0Jy5SeKJcInQFNREAw8HJzkzSdTXlU6nD8in01sf4/u2r+NruNRyrjmMpYgpzga4I3rcxyv2Ns8ne7GHRCfdQKERnZyft7e0L3ZQbGnfddRednZ3T5a91pJQvu3BjxUvmN6+mLikltmUR9GkkEzEGh0Zxc2moaULdsJMH2tezbdcuDu0/yFMHjzOQSrOlsZZNTbVU1SRQYxFkXQsyHAdFQUiXhGl4HjVjA2jlAoqm09M7yPMHT7G2Jkl9LIKuq2i6jj/gw+f3IYwiGMXz+pQQIBRQVaTmIxAI09zaSnP7CmoSSQ78zffZLKMMWhkUX5hnSXHKLbDO38aRo8dZ21DDUCpLIOCjsTrhXSsCx7ZJj6YxDJvhXJGNrfXUJGOeb74vgNu8GmW4l/Eow1g4wI72Fp46fgb/UIpc2aBgu9yyuo22WJSArpEvGwznCxiuQ0AVICWqomCg8vSZPt6wezP/ue8YK1etXBAvmZmgbq4n9r9eQeqXv4EzcD0oRi7UgKfTiC+nZV9ai5aAElDx7ajDt6EG86VBzMMjs9DdL2+EGd/rqoJCbZixW1r5xOoWfrSqkaGwH+eieylRhOBt7WF+Z1MYTcx+fe6ywl0I8e/Aa4EhKeWWyrY/AX4VGK4c9odSykcr+/4AeA8eUd5/k1J+b1YtmYRkMolhGPj9M4fWLuPaUC6X5ylorOJ2GvMCshrb2tEdh5HefiL5Ar6WFShNK6ndtov71m/m7gf66T15lP0nzvDwgZOsq6tiQ1uGxNgwSiyJqG5AhmMITYNkHW6iFkp51EKWLckaIrE4B46f5nj/MGtqq6iLRdALZTRdxR/w4Q/6J8wWnq+8DRYIUUYUcyipQaSm014b44chmx35MLVaNToaa4hwQhQoWyYjqSz5skFLXTV1VYnzNjgpyWfyWKaDpipsWd3q2dwLBSINzThtGzwmy3waLxBK4kqoiYRY11TPl54/yGs2trOmsZ6aWAwElE0TPeCjORnHtm1GM2ny5RIWKs93DfKG7eupTUbBFyKRTMxLn84aAvQH1xH7nw+Q+b3v4RYsrsxGMz9W+glNWhH4t9cSetsWnK4cxa8cwZlYFL7A/DYjRMWYM4mmWgHTpzJYG+HI6hqe2tRG/I52nJYEXz5XPM/bP+UN4m28t97PX+yOkfTNzhwzjtlo7v8J/APwXxds/zsp5cemXJIQm4C3AZuBJuBxIcQ6KeUVEcfEYrFl7X2OMTQ0NJ3WPmfw+TR06UJ9C4XBEQ6/dJCb21303BEi2TT66k0owQhKy0pW1DWxYtMWcn3dnOrs5tsHTpHw6ySCfsq2Q008RmtdNdFoGC0YQo3EELEqRLKO9sZVtK1ZQ6a7gyNnuzl66hyN4SBtVQlCfj9qrog6zps+KWZBCIFQFBRVQVFUbMfF0VwGC8MEfCEKmkJ/HJJN1dRXJxF+P61VcaoDuucxI1Sk8LhhymXDc7PVNYqFEtJxiLW0IFZvgUIGZaTv/AKsBMd2kBLiAT+3tdfTkogSD4e9yGnXJZvLEY96nkyaplGbTLL/yCgv9gzy87dsozYawnRcQsnkgpgzp3jLTAdVEPilm3BH8uQ++mPc0vzFs8wWAlDrQ4R+cTv+u1aQ/3/PU368Ayy3ImunauUziVipCFxF4CiCQtSPujLJvmiIQ+21vNBcw+mGBH2hAJoq+KNNcT57tlC5f9OXuL3Kx9/emqAlfD447rpp7lLKp4UQK2ZVmhfo8gUppQGcE0KcBm7BS9N3RaiursY0TXy+2duYljE7GIYxL/S+45BSYhRyhMI+xEg/jZu28eyZHr595AwPrG2Hnm4Sro1oW+tREPgD0NBOtLqRne2r2b4jRdEwMVAYzXtJVwzhElZd3EIONz2KUDrRgiG0aAIZjpFYuY67kwlyY2M8d/Q03z58irCuUhMOUhMOEfHr6JqKpqoel4xQPDZIxXOBNB0HHJez5OmIGtx63xbecvNGmpIxFCFwXJeyaZHLFynli0RiUXRdI5PKefQ4SDqHx1CFYO2mDahrt4N0UAc6wD2fsk9KsCv0AqqAFVUxIqEwmqoCkqJhYDl25bd3L31+Hzlb0pyM01YVRwjBUK5AvKYO/Qqyfc0r/Bqh37kTWTLJ/93zuLPmVZmdqeNqIalo67c1E/3zl4HlkP3d72EeHr7suQC2pvD8jmb6YkFywQCZuhCDiQhH41FysSDvu62Wj58z6DUn5ayQkg0Jrw/PzJjxBzbHfXzy9iTbk1dnPb8Wm/v7hRDvBPYCvyulTOEFtTw36ZjxQJeLMFOwyzgikQgdHR20trYuitX/GwWO4zAwMDCvsyLXdUn39+EGk6QzKQI1Kd7y0Bt46sfP8q+P/ZBfuWM7/tQYUXESt5RHRhLgD1WSiidQfX6ilkXMsahNuuft5EiEaUC5iChkELYFuTFEbsw7F0EsHOTBXZu5bf1KeofG6B5JMVwyGCyUUYVAE5KasB+tEig07h3RlcqzRyuz+1Ub+P27d7C6rmqCr0VICYpKUNeQoQC5dJZsKoemqxNa+LGBYQI+jW0bVuNbtwX8AUTPabDMqUk2HAfb8h78sK6hRsJEIx5ZnCslnSNjVAV9KIoCVOiKw0FOjWZ4YFWzN+MQMJorsnrztgVxgZxNnUIICPsIf/g+pOWQ/4e9yPJ5dtb5xvirQgmqhN+5jfAf3I+9v5fMB7+DfTY76zKyYZ0P/fzddCciuBc4x2yO63Sh0T8R/+AZafyK4LUtQR7pKlaywV1wohRsjuv8y51JdtfqE0FsV4qrFe7/F/hIpcUfAT4O/PKVFDBTsMtkNDY2Mjo6Sl1d3VU2cxkXYnR0dArtwHzAdVyCroM0LEzHxerrJ+y43L9zK75SlidPneUOp4k2VSVgmSiqBpqGEAq4jmf2GHcdmBgp4rxH2/izMdnvXU5yNVAUYrEI0UiIlU21FHIFLNOmbJhY42VLkNLFcly+f+wcHbkSv//uV7OjvXEiJmF8+iwVxXvBSG/KHgqHKBUNLMvLC/DCuR6qw0G2rW4luGIdBKOetp5PT32MpcQoG17ybAS6qhJOJFAVT5kpWxYjuTx14ZqJS9J0wXCxzJmBEX75ls3eZSsKI2WT9WvWXOeeuz6YEP5CQNRP5H+8DOHXPA2+uHAmGjXiI/rhOwn+5m1YT50l/VvfxunOX/7ECgSQqQ6RD/o8wT4xNiWqEDzQGOCxvhLuBUuxu6r8FEyX4xnLuyeTzgPBtqTO/7sjyS21+jW99q5KuEspB8e/CyH+BXik8vOqA12mg9/vn+B6Xyjt3a9AUD3//aputq5XNElmlZFprjB+H+fb1CUUQV6onBscoTEewafpFAYHEeUC97TXsqk6wum+IZKFEmYlJD8QCuFWhJ9t2oxzDMjKZyIaEo8yWtFUNF1F0zSEokzIfem6OI6DbTkVrVqi6TqO44KAYqlIqZIcpWg5fOd4N6vamviz195LPBg4bxSQEhQFt6YZGa9BqhrCscEoooz2o6UyWKbD06c6sS2T+7asJlxVhVtV7wVbWYaXzHuyOca2KeZLFdO/xKdpaJXE2QLIlAw0QUVr96DpGntPddMYDVEdDiGlxJGCU6MFHmhpXhDN/XJa5UX7o37Cf3A/SiRA9i9+hJs3mU/tXQJq1Efszx8k+Cs7sX7SQfoDj16RYB9Hb0Oc8jQkbmsiGpoCx3OTqcwlMV3hFc0BPnkqj32B0q4Iwa11fv7p9iTbEuo135GrEu4XEEa9CThc+f4w8DkhxN/iLaiuBV64lgZWV1fT3d1Na2vrvA9cBXhlPdxW6Z+gCuErvWM+H+zadT47k98/fXTTHENKSV9fHy0tLfNet6Zp/Ox738sX//7v2Jzqor0qQVU8QT6dp5Qr4tNVtjfXeb7plcXOQr6AUTS8JC4V2TCTCJl8OxVVRVWVccUa1/FS8MlKNgyPzE1SLpfpT2fpSaXxKRDy6Xz3RA93bljFG+/Ygaadt3GDAFXDaVqFrGqYeFFLQETiyGgS38go2YFhzgyO8I5btxKOhpHJeqTu8yid0yPeLIRx11CbTCqLU8keJaX0XkxC4LgO0pWkC0Uift27HuG9rhRdZ8/pHu5a04qmeqaa/nyeYihKsip5vbtu7hDSCf7OnYj6CNk//sEkwTqbACS42iAmiaexx//8QQK/tgvn2DDZ3/kOTkduhrouwf0i4HBDkuIU4S7RFcErm4N8r6dUybFcMecJwWtbQjw9bNI3MWMRE+c81BLir26J0R5Rr9oUMxmzcYX8PHAfUCOE6AH+GLhPCLED78o7gPcBSCmPCCG+BBwFbOA3r9RTZpr6qa+vZ2RkhJqa6dnw5gJSwogJPxyGgbJ3oQ1+eKAOan2zlM9SQrEIZ85ArhLJGI3CmjUeL828XYtkdHSU+vr5ZwoErw9XrVnNr/3ZR/jqf36KZ5/8Pttq4mxsbqA2HsNxHIxyJRmFAqbtkC+VUaQE6RLwB/Dp+qza7lRyol5Y/7imXCiXKJRKDGbz5MomTXFv8fKpM728css6dq5opFwo4vP70H06hOPIcNQT1KHoVNPPOHQfSiBEulimNhQgFPCj6j5kogaQMNKPMtzjzTwA27JJj2VxbHtiDIxfmytdcvkC4VCQwWyOlogPVT3PP9SfK3Kmf5h37toASISq8MOT3dz1hrcuuOvwdHldZ9oHgE8l8M6bUFclyH3we5j7B6fhgb++C6lKSCP2P+8j8Gu7kWNFcv/9e5iHrzzASgKWrrB/bcMUSyESdtf4yVouJ3L2lDN2JPzEfApf6SycP0FCla7w6xsifHBLlKT/ytwdL4XZeMu8fZrN/3aJ4/8C+ItradSFGB+0tm3PmzeALeHbA3Bq0kxt2ADThbe2gn82999xvJyqI5MGTz4PlgU33TRvJprxLFcL6XkkhCCZTPLu33o/z+zYwcf+9C/Q9p9iXX01G5tqaUrECOo6g9kch3sHiftU/KpCxK9TFQ5SHQkTD4UI+v34dX2KqWJyHdMJGNOyyBXyjOZypIoG8aCfoM/HSMnihd4xsoaF40oypTLPn+1hc2MtAV3HH9AJB6JotS3gC8z4Lh73eMmWDXTVW8hFCC/gKjOK2n+2sm4Atu2QGRfsXNzWbD6P7dgYtkuuWMIXD+HXdaSUqLrGt144wvbmWmoiHntqf75ArxbmVx64d0H5ZK4Gnv+3QL97FYkvvZX8n/+Q4uePIo1LLbReXRCTBISuEPn1nQR/4xaQksLHf0Tph+cuEZwkL/omJv3PJIMcaJgUKyIlNQGVu2t8/MvpvKe1V2zqDUGVe5uCfOZ0DtMddx2F1RGNv7gpzhtWBPApsw9Qmg0WXYTqTKitraW/v5+6urp5sb/nbE9jH8d453YWwXA8+/tlYdswXaLiXM7LtToPCakdx1mQRdTpIIRA13Xuvf8+amtr+crH/pq1ionrWvQMDVEwHapCfm5tqUFVBJbjYjguedNhbCiFEGnaklGqwkE0VcWn6+iajl4xZ0yGlBLbccgV8qTyeTpGMxQsG6FodOUMtGCAlvpa1sWj1MXC6FJSLhkMp7Mc7R8m5NNZ11CD29lBIJMm2LYSWd8G2jSLXI6DVSySLRsULRspXVwpPWKxgQ5wKqYXV5LP5LAse9r2pvM5MvkcdclqBnIFqoI+wsEguqYjBKRMi+dOdvLhB29DEQLTtvnaoXP87Ps/cBGj53zimgWSAGVVFbH//Xp8u1vJf+zHWB1Zpgrpq9fgx0sJPrCS8H+/D0I65rdPUPi3l5D2lSXOmIx9axsYiFWSgktJQFF4e3uIx/rKpEy3ItglSV3lbe1hvttdZMTwPKM8M0yQP7opxqakhsLF93EKlfJV3OMlI9wBGhoaOHXqFGvWrJlWc7ueUMT0b3Nthu0zFzQDH/w8sEK6rsuZM2dYu3btnNd1JRBCsGnLZt742x/kU3/2x7xxTSNNyQR+XUcoSiVq01s0VcYJwSYYF5kIPhIXmDTGF1st26JQKpEvFRnI5Dk2lMZF0JiMs629kZXN9UTCQXAktm3hOA6KoqAlY7SvaseRIFQNJRT2FiyLRaz+LnyODa3rYLwtlSQsTmoYt1SkayRFQFNwXInrgjY6gCgXJ+ynpWIJozyVn2S8zalcjoPdfaysSaLrOp0jY6xIRIlFot6isary2MGTbKyrorlCZfD4iU7a7nqA3bfcvKi19pnaNrnfAETET+DXbkG/vY3C/3qa0rdO4haujzeNtjpB9KMvR9SGkUN58n/1NG7KuCrBPk4f8MOdKzAq41UR8LKWIGfyNvszFuPRxxFN4TVtYR4bMjiesxDA2qjOb2+K8PNrQsT162eGuRBLSrgLIVi9ejXZbJZ4PD6nAzqqwboo7Eudf/MLYGPsvPfMZaHrUFcHPT3ntwkBtbXeQuscQkpJNptl9erVi/LBF0Kwdcd2Xv3rv8V/fPxjvHvnOtbWVV8y9+eFOpyUEtd1sR0H07KwbAvTtrAdh6FckRe6BnFRuH1NGxsaagn5Nfx+P45h0ZvOki+Z5AwTy3GpjYQI6BqRaIRwdQ16XR1UNyI1HRWJNA1wnQmhLgoZxGg/lMuUhoewTIu+VJb71zTiOC6OZeFLj3jC35UU80WK+WKFil5MXIjruoxlMxzoHiCkq9TGY3SPpUkGdBqrqr3gJQEZ2+YnJzr5nftvRhGCE/0jvDBm8lc//zY0bWEf48tFqF4qqnLKoqEAoSqoNzUS++Sb8D9ynMLHn8E8MFTJ6nR1UPwq0d+9A3VbI7iS0ucOYLzQd1U8j5Vm0tcU46k1TVDpz/vq/TT6FP7rbHHimiKawuvawuxLmxwfM0n6BG9eEeZ3N0dYG1en1dYnY0pS98utX0yDJSXcAVRVJRwOk06nSSQScya4FOCVdVDng64KC3FrEG5KwIVJ5y/RWFi3DsJhzzwjBCQS0NQ0p4upUkrS6TSRSGRRB4ApisL9L38ARVH4P3/9v9iV7OG1W9dSM4v8sY7jYDsOruviSrfC+a6TMW2O9KdIFQ3uWr+adfXV+DUvClUIgWHZ9OeLDBXKNDfW0RqPEfLr+JEMj6XoGRmjOp8nmR0jWD8K7RuQgRD4g55gdxzEWD+ivwOrUKBUKFEqGfSNjtKeDJMI+lEVBSEdzGIRo1zGNCxsy75AsHtmo+F0ij0dvUT9PlbXVWO6UCiX2dzShK5pIAQFy+Kfn9xLsD+PdFw6R9P8n+8+S32kqZJz9eJ75TgOu3fvprm5mUceeQTAJ4R4HqgG9gG/KKU0hRB+PGqRXXgZg98qpey4Xn181Yj48L9tG757V1L+/H4K//Yi1skU0rl0+P908N/Tjv/t20ERuB1piv+0BzlBK3BlGHd+efy2VfRFgwjgjmo/6+M6nzqdxwtEFVT5FN7YGuLZMZO+vMVDbUHevzHC7fW+625bnwlLTrgD6LpOKBQilUqRTCbn5EYJASEN7qiG2yvbpqHTvjx8Pli5csKUMFH4HEFKSSqVIhwOL95Q9ElQVZX7X/4Aq9eu4Stf+BKfePYnrPTBfWtaaatK4NMqC5STIISXnEJTVcq2w2i+wJGeIY6d6EELazyweQXrtqzzhCOSYChAOJkA3YcIhKgJRSGagEAYWfGJR7q0lIvUDfZQ6u2mVChgdHSgp9L4mtoRkRgKLurYIE5qmHw6h2WYGJZH5OXYFtubakhEY6iqQiFX9AS6e7HGJaXEsiyG0yle7B4goGusqokTCYXpzxVY31BfEeyQN0z+6ck9pPZ0cXPZz/e+8QKHNJPq7iLaOgdXTq/R/v3f/z0bN24km52ItmwBfkNK+QUhxD/jkfv938r/lJRyjRDibcBfA2+9Tt075bpn2nehy9+U4xujBD9wF/6HtlD+4kFKnzuIeXxsVsJZAmrSR+RDdyDiAXAl5S8exDqbvmo7O8BoTYgv716LC9xS5WdDUufTZwsUKy+eppDGyxuCHE2ZbIqo/N3uOHfW+67cjfoasSSFO5z3oJlrDV5cqY39UgXNMcY19nA4vOBucVcCIQRt7W38zn//XdKp97B3zx6efOppiofOUqdI6oM6zbEo8ZCnFaeLBh0jKU70j9LTP4o9lKclD42mQvnWOqqj0QluFn/ARzQRBZ+ODEaQ0SSEY0g94PF12zY4FhhFkOCra8ZXXY+dGiF39gw/3neIwrMv0lwVpzHhuU2O5orkimVyZYOSYbC6torGmhiqolRMJALbsJmcmWeyYC+Vy4xm0pwcShH0+1idjBALRwj4fazw+9EqybZ7U1k+9aP9FA72c2vZj46gtiPPJtVhVIXYbZuIRC5Ou9fT08O3v/1t/uiP/oi//du/HReeUeArlUM+BfwJnnB/Q+U7lf3/IIQQ8gqcrOdSCxVCgCpQViQJ/d49BH5hB+a3T1L87AGsg4O4WXNCb7qwFQIIvGoN+l0rEIA7lKf0pUNI9+oXUVHgu7ev5lhNnLtr/GxI6Hz2XJ6C7VHz7kz6uashQEiDX12f4KYanZB6dffop2pB9UKMR7BmMhlisdicL7IuZriuSzabJRKJLAmN/UKML5omq5I8+MpX8MDLX0Y+n2ewf4C9L+zhJ2dOozswNjTGM0/8mNtHfcQNi522QxgfftVHhhK+oI89Hd201hTZ3tqIP+i95IRpeDw02VFQVFB1KkZvL7hoXAMWAqn70UNRquqruTegcqqzn7PDKY73DRHUNWIhP3XxKC01CQKKen6dYJIRVyIplMsEfT5UVfW8d2ybQqlIppCnK5UjEAzSFg1Usk1FJtEO2Dx9qpMv/eggvuESD5YD6JVS08LlRJXO1nc+xK994DenfYl/4AMf4G/+5m/I5bzAnNHRUfB4+sdXJydzPk0kPpdS2kKIDJ7p5iLn75n4oC7HVDhrm/sltgGgCJTmOIFfvRn/27bhvNRH+WtHKD92BrsjgzScSRNkiRLXCf3ybgjqSMD8UQfW0atPGiKQ9DTF+M/7tnBnc4jWgMJnz+YxJayK6DzUHuLNK0I0hgRNIWWCe3180XxKWbMQ1j91NvcLoes60WiU06dPs3r16kVtY54rOI4zcf0Lvbh2rRgfuJqmkUgkiMfjrNuw/rwnjGmx5/kXePZj/8n6vQPYRp6sXSSgB8naJTRVYXNdguF8gefPdLNzRROhgJ9AyE8gEEDVVE+Yu870TnZSIowSTj6HbdvYhkVjLMKGFU0oqoJ0JYqiYJQNjLKJbTkXLShKKRnOZBCKSsDnI1fIUyiVMC0LV7oM5koEQxFWJiOUjTLV8QSqquBKScdomv/80UuMnhjkrqKOJX14Xt+CgnApvu42fv+/v59NWzZNRLROxiOPPEJdXR27du3iySefvK59cyk+qCuhor1mCBAxP9q9K4nc1U54MI99eBDj+6cwX+jBOjyKWzTx396GdkuFDcV0ML56FNdwmX0218nHSWxd4auv2s4tNzXgCEFf0eFX10W4r8HP9hofzRWBDvNjU78clrYkqEBVVdauXcvg4CDV1dXTDvobEeO229HRUdatW9ikyHOFC90d1aDKXffezcoVK3j4Y/9M4fv7EANZSsLCj4ptCUKBAPVCMJArsvdcD9tbGkinM+Rth3gsQm0iis/vm1AEHNvBsixcp+J+qQoc28E0LSzTxrRdyiWDYCiAZdkMjaWJBbxZo+7zHiHL9JTicbNL71ia9pokAyND2JUAJsN26EwXaKutZkVVgnQ2Q02iClXTeO5sL0+f7GTg5CBrRm12O37USTxpJeHSe9MK3v9X/4OWtpmpOJ555hkefvhhHn30UcrlMtlslt/+7d8GUIUQWkV7n8z5NM4H1SOE0IA43sLq0oCqIJpi6E0x9JevQeYM3O4M9v4+1NYkIuJ5pbndaYw9415rs7U4yYm/QgiyD6zivt+5hca6MCEN6oIKUX08Ynn6F8a1UghcC24I4Q7ezW9oaGCkEg1aXV19Qwq7cYxTCkgpF0WA0nxCCEFzeyu/8rd/QndHJ/t/+COe/MzX2XrYJNeZInz3FoL+AJqi0pfN86PTndy+qhXDKPHM4ZOUXUlTMsHquioSoaDnV+9Kj8Md7zH1+zRCkRDBSIgXz/Vx6Ohp4n4dn6azeXULVXXe+LIti8zY+YAby7YYzabpSWWI+z3yp5xhcW4sh+7zcfPKdqrCAbL5PFXxBIqq8u1Dp/jCEy+xISO5y/Thx7PbjxNfGric2VjPuz/xp5cU7AAf/ehH+ehHPwrAk08+ycc+9jE++9nP8rnPfS4HvAX4AhcnPn8XXs6FtwA/vBJ7+3h/XO3+yy6oVjCbJglVgXgANR5A3VI/ZZ+9vx+n98qJwcahbUiy5q8fZNOGqcFik9u6gHJ8Wtwwwn0cNTU1mKZJd3c3zc3NN6SZxnEc+vr6qKurW1ILp9cTQgh8Ph+r1q5h1do1qFUJvvX+P2Fjn8Fzh85x+7ZVNNTUEgmH6R4Z4wdHz3DXupXcs2ENY9ksJwaG+UZXLyF/gGQ4SNG0GczmKVsm25pqWFebJFYIE4tE2NZcy/qWOg6c7aMhGmBtQ3WFbdKtkH+5SAlls0wqnaZsWiChcyzHqZEMQX+Au9evoDUZ9yJLTZNoKIwLfO7Zgxz48UleU9CIScEU5hoJZeHSu62V9/zzR9m8beu1KCw9wAeFEH8OvMR5CpF/Az4tvMQ6Y3iZ1K4I183P/RLbrgYTLw4J5g87kNbVLaSqCT/RP30Zvq0Nl31RzWbbbPFTvaA6E3w+H62trYyNjeE4DtXV1TeEkB+nElBVlZaWlht6ZjJbjD/Am7Zt4fFIkDOpLAcfP8C3D5/mFTet5Y717axvaSYcGOaRA8fYvaqNzY21JMJhNhTz5IolypaNCKpsqYuTjEYIBwKer7oQOI5DMedFmTaHfGhCYWw4hXS9KFrTtDBMg2K5jGGZSCnpSuV4oXeEl21Yyet3tVEXCaEoygQ7pc/no2TZ/NePXiL1bAf3lnWmI3jNCZeBW1fzy//4UdZuWH/F/X3fffdx3333jf80pZS3XHiMlLIM/OyV3/n5xWyvfdrjiibWyaGrUq2VsEb0f9yN/w2b5sPh7brihhTu4HVydXU1hmHQ29tLfX39ktZyDcOgv7+fpqam5dSDF0AIQUNTA9GWBloGSxRtie+cyWDXEf654TQbdq/iznWtvGx9G0+d7GYgnePOVS2EA0FC/iCq6qXb0zQNwaQAKenRBTuui+u4dIxl2NTciFE2yZeKlMplLMeeomlmygYjZYffftnt1ESCgJcHtWyUsWybcDBEzjD51BMvYu3pYYupoUyTiSejuow9sJ1f/8RHaFvRfkO+yOfLHu2OlrBPjk1yZrr8gqqkkqXpA7cSfN9toCvz4s58PXHDCvdx+P1+2traKBQKDAwMUF9fvyBJhK8W5XKZoaEhqqurWbFixUI3Z9EiGAySWL8K/cVu/NLGAepsheoek6GBo3yy4Sw33baWl29azd6OXr558CSv2boWTbgUSkVURSHoD3hui65H/OW4npAfF/ZD2Tx+f4qE5mJaFpWQ0wmhMZQvcSZV4DXb1uNTBJl8HsuycFyXaChMOBiiL5PjXx/bQ83RFOtslQsJhKUUDOgu6lvu47c/+j+oqZ0/muvFjFnZ3GdwGZQjBdyx0hWZZJSQSuS/3ULk9++D0OzophcbbnjhPo5wOEw4HCaXyzE0NERdXd2iFvLjQr2qqmraHLPXo/x77rkHwzCwbZu3vOUt/Omf/ikstTD1CjRNo2HTWpTQAbRimrOqScgWaAgaLZW6HpPObx7iyOoY99+xCU1T+I/nDvK2XZuoi8cplg2yhRymZVWEtagEsHnRsD6fn9vWrODRw2e5uaUKDbwMS3gxBp2pPMeHM7xyQxuZTArHdVEVhXAwRDzqxWD85GwPn398Hzv6HRod9SL7uiskHSFB/a+/lXd96P3EYrElIVSudkH1QuKwSx1/LVq+O5jFdSafP3NZElCiOtHfvY3QB++BiG9J9MF0+KkR7uOIRqNEo1FKpRJdXV0EAoFFY5MvFosUCgXK5TI1NTVzItTH4ff7+eEPf0gkEsGyLO666y5e9apXwQKGqV8r2jav50BAZaWbZMQYZlh1aHS8MH4VQZupYB7P81TXc0R3NHPP5nYO9w1TFQqwubmOumAQy7YoGyamZWJYJpZtY9o2I7k851Ie1/q3jnZye2s1PlWQDPrpThcI6RqvWNeMJkDXdOLBoOexo6p0p7J8ae8RTu3v4u68RsJVLtDYJYaQHIopbP/dX+Ld738ffr9/yQqVxQZ3MA/O7IjHtIYQsT++n8C7dkJgabtU/9QJ93EEg0Ha2tqwbZtcLkc6naa2thYhBKF54FkfR7FYJJfLTSQCTyaT8xKIJISYCF23LAvLssYH8pyFqc8lhBBs330Tz29sJHgwRaMVYp/IUOuoaNLzKZSATwrWFxXyz/bx6NF+arY2cdO6ZtLFMvWxMD7dh0/3TQRNlQ2DbDGPogg218UpWjYdYwqnh9PURoIkg35WJCMoFS09Gg6jqholy+bsSJrHjp1j7+EONo66vMr2cSEbvASGFIcDzWHe/D9+hzf93JuXXJzG1XrLzDR0rveQclMGXE62KwL/LY1E//JB9LtXgDo5KfrsZhnTmoRmuJblCNV5wHgkZCKRwDRN8vk8fX19VFVVoes6qqpeV2FfLBZxHC9oJp1Ok0wmqaqqor6+/vInX2c4jsOuXbs4ffo0v/mbv8nq1avhGsPUZwpRnw8kk0lWvuVldB36LE3+OAmjQI/msNLWCOlhHOlQtr2ciVEUdqQlI8/08IMDvcQ3NXD3jjVsaKjBp3k5LBGCUDBIMBDAsm1K5RIBo0w04K9weCugKHSnCxwaGGMkW8SPIFcw6UtlkBmDtrLg1bZOWKpIOZWoyERyQDdJ7VrN//d3H2Xzls1LjkJjstC5lFCejcCeKz1Bpk1wLy57fK1ESfgJ/9J2Qh+4C6U1PidtWAj81Av3yfD5fFRVVVFVVeVpbeUyhmGQSqUYHR0lGAxeVeKL06dPUyqVqK6uJhQKEQgEiEQiVFVVXf7kOYSqquzfv590Os2b3vQmjh8/fs1lXipEfa4hpeRcVxc9zhjtWhNrrTiPiRHqHRVhl6gP1eH4bMZKKSzXRgjwAbUFh8RzA3xvfz9faIuwam0Dd65sYUN9Naqq4LgezYWu68QiUVzXBSTPdfTzlX3HGDs3SlNJUOeq1LgK7Qi2ARp+hPTs9uOZ97yGQkZxed5f5kxC55/+4n+yZeuWJaWtLyXIsjOtmV3ogsAdLUT+8D70e1aC/+LE1Bf2yVLycxeLYVYthMgBJxa6HdcBNUxDuLRE0Ig3eW0GfBXt/HbgT6SUrxRCfK/y/dlKmPoAUHsps4wQYhgosHTvyfXAYhkT7VLK2utV2BJ6ZhfL/Z8NrqatM/brYtHcT0gpdy90I64VQoi9S+U6hBC1gCWlTAshgsD38RZJ38V1ClOXUtYupXsyF7iBr39JPLNL6f5f77YuFuG+jPlHI/ApIYSKl3jqS1LKR4QQR4EvzEWY+jKWsYz5w7Jw/ymFlPIgcNM0288CSzZMfRnLWIaHxbI0/8mFbsB1wo1yHdcTP+335Ea9/qVyXUulnXCd27ooFlSXsYxlLGMZ1xeLRXNfxjKWsYxlXEcsC/dlLGMZy7gBseDCXQjxM0KIE0KI00KIDy90e2aCEOLfhRBDQojDk7ZVCSEeE0KcqvxPVrYLIcT/rlzTQSHEzoVr+cJgqfTrtUAI0SqEeEIIcVQIcUQI8duV7TfsuFhs/brU+kAIoQohXhJCPFL5vVII8XylPV8UQvgq2/2V36cr+1dccWXjHBoL8QFU4AywCi9Y8ACwaSHbdIm23gPsBA5P2vY3wIcr3z8M/HXl+6uB7+BFN98GPL/Q7V/u1zm5zkZgZ+V7FDgJbLpRx8Vi7Nel1gfAB4HPAY9Ufn8JeFvl+z8Dv175/hvAP1e+vw344pXWtdCa+y3AaSnlWSmliRc484YFbtO0kFI+jeffPRlvwCPXovL/jZO2/5f08ByQEEL8NCU6XTL9ei2QUvZLKV+sfM8Bx/AifG/UcbHo+nUp9YEQogV4DfCvld8CeICpRH2T2zne/q8ALxNXyEGw0MJ9goyqgslEVUsB9VLK/sr3AWCc/WupX9e14qfu+ivT5puA57lxx8Wibv8S6INPAP+d8xyV1UBazoKoDxgn6ps1Flq43zCQ3vxp2a/0pxBCiAjwVeADUsrs5H3L42J+sNj7QAjxWmBISrlvvupcaOHeC7RO+t1S2bZUMDg+pav8H6psX+rXda34qbl+IYSOJ1Q+K6X8WmXzjTouFmX7l0gf3Am8XgjRgWfOegD4ezyz0DhTwOS2TLSzsj+OlwFt1lho4b4HWFtZMfbhLRw8vMBtuhKMk2nBxSRb76yszN8GZCZNEX8asNT7dVao2ED/DTgmpfzbSbtu1HGx6Pp1qfSBlPIPpJQtUsoVePfth1LKdwBP4BHxTdfO8fbPiqhvukoXegX+1Xgr3GeAP1ro9lyinZ8H+gELzzb2Hjwb2A+AU8DjQFXlWAH8Y+WaDgG7F7r9y/06J9d4F950/yCwv/J59Y08LhZbvy7FPgDu47y3zCrgBeA08GXAX9keqPw+Xdm/6krrWaYfWMYylrGMGxALbZZZxjKWsYxlzAGWhfsylrGMZdyAWBbuy1jGMpZxA2JZuC9jGctYxg2IZeG+jGUsYxk3IJaF+zKWsYxl3IBYFu7LWMYylnED4v8H8+YhkHiLSIAAAAAASUVORK5CYII=\n",
       "text/plain": [
        "<Figure size 432x288 with 3 Axes>"
       ]
@@ -651,11 +628,16 @@
    "source": [
     "# display the false defaults\n",
     "\n",
-    "indices = false_defaults + len(histograms)//2\n",
+    "false_default_indices = false_defaults + len(histograms)//2\n",
+    "\n",
+    "filenames = [files[\"filenames\"][index] for index in false_default_indices]\n",
+    "\n",
+    "print(filenames)\n",
+    "\n",
+    "images = [np.asarray(Image.open(files[\"filenames\"][index])) for index in false_default_indices]\n",
     "\n",
     "\n",
-    "images = [np.asarray(Image.open(files[\"filenames\"][index])) for index in indices]\n",
-    "\n",
+    "# show actual images\n",
     "for i in range(len(images)):\n",
     "    plt.subplot(1, len(images), i+1)\n",
     "    plt.imshow(images[i])"
@@ -663,38 +645,385 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
-   "id": "51c2ca8a",
+   "execution_count": 75,
+   "id": "756437f4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXAAAACCCAYAAABfNJOZAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8/fFQqAAAACXBIWXMAAAsTAAALEwEAmpwYAAAMXklEQVR4nO3dT6gdZxnH8d/TSrNQEa+poTalUyQIpYldXOLGxYhWorSkK2nc9EAxbrpxF3ThwVU3Ii5EiBpONrauShspag0cunHR241Xxf6xjDSxTRquSEVIbH1c3FO4TeeZe+acOTPzzvl+INx73pl533fOc+7D5JznvGPuLgBAem7pegIAgMWQwAEgUSRwAEgUCRwAEkUCB4BEkcABIFEfWeZgMzsh6ceSbpX0c3d/Yp/9V16zePTo0VUPsXLb29srH8PdLdpWN64bGxt++PDhhmfYruvXrtU+5sDBgyuYyXK2t7evufvt0fY6sa0d15crnsMseK4OzN/9OoviaovWgZvZrZJekfSApEuSXpR0yt3/UnHMyhN4URSrHmLlsixb+RhRAl8krseOHfMLFy6sZJ5tKSaT2sdko1Hj81hWlmUvuftm2ba6sa0d13wSb5uMggnP3/06i+K6zFsoxyW95u6vu/sNSU9JOrlEf+gH4jpcxHZglkngd0p6Y8/jS7O2DzCz02a2ZWZbS4yF9tSO687OTmuTw1L2jS1xTcvKP8R097Puvhn9tw5p2hvXjY2NrqeDhhDXtCyTwC9LumvP48OzNqSNuA4XsR2YZapQXpR0xMzu0e6L4BFJ32xkVjND+EByEYucd4MffK48rv1UVGwq31ZMynfv44ebM83EdjQtby8qjslqj4I5LJzA3f1dM3tc0m+1W5J0zt3/3NjM0AniOlzEdniWqgN39+ckPdfQXNATxHW4iO2w8E1MAEgUCRwAEkUCB4BELfUeeFOGUm1SBO1ZG2MHz2EbX8tPynRa3l7Eh2RZHmwJDopez6nF4vr18nOJnsPUzm8AuAIHgESRwAEgUSRwAEgUCRwAEkUCB4BEkcABIFG9KCPsVIMlX0FPrOPTI0W0oSLeRbAtCzorppPy/UfjcIxe+scNaVzMv/84j7eF3UQbslrN64orcABIFAkcABJFAgeARJHAASBRJHAASFSrVShHjx7VhQsX2hxy7ZUtcvXQQw+1P5GeyIL2ouqgmouthYVNtXrpgX9fl6ZFyYasfP/xNO6r7oJ1UVXQdFSvnyYVQXvW4hxuwhU4ACSKBA4AiSKBA0CiSOAAkCgSOAAkaqkqFDMrJL0j6T1J77r7ZhOTWoUibM9K26N1LrKKeoV8/unMOisfuw9Sim0dYTFEabXF7JioPXyRZPNOp3UrjWtRsS16TkZRe77UVFYieo3kWXl70NykJsoIv+Tu1xroB/1DbIeJuA4Eb6EAQKKWTeAu6Xdm9pKZnS7bwcxOm9mWmW3t7OwsORxaVBlb4pqs+eOq/3QwPdSx7FsoX3T3y2b2aUnPm9lf3f2FvTu4+1lJZyXp2LFjvuR4aE9lbIlrsuaPq32GuPbcUlfg7n559vOqpKclHW9iUugesR0m4josC1+Bm9lHJd3i7u/Mfv+qpB80NrMFTYP2LGiPPkCOyhWmFRUGebil3hhdVzF0GtvoOam5wEgxKd+/bG2Yqn4qx44E1QrTYlzano/L25tWP643VFpaMh6V7x5VlAxF3vUEPmyZt1AOSXrazN7v55fu/ptGZoWuEdthIq4Ds3ACd/fXJX2+wbmgJ4jtMBHX4aGMEAASRQIHgESRwAEgUa3ekadLWbShiA4oPyLsp6qrimPWUlVVx3Ra3p5F+wdDBP3kwRobRdVCHsFroYjWxoheO1E/k0k89GgUblu921T6xEd33snyuKuw3CslWXlzh9VkXIEDQKJI4ACQKBI4ACSKBA4AiSKBA0Ci1qYKJVJk5e1BMxUldQSfzhfFNDwkq9dVWAkSFgAE7VlFZKN1VbI8D8aO+irvp6oAJqpQaaU65WMHpM3sw+1RpdBoEvcVPSc9vnvR/Iry5klWv6uah3AFDgCJIoEDQKJI4ACQKBI4ACSKBA4AiSKBA0Ci1qaMsAjas6B9GrTnVQsxDaIkqjlRuWBWdUzdLUEZYZGX755FA1TEdRpsy+vWfAVDVC6kFR1T9zZvizh4W/lt0qYL9FX3VnlJyYL26cpH5gocABJFAgeARJHAASBRJHAASBQJHAAStW8Vipmdk/SgpKvuft+sbUPSr7T78Wsh6Rvu/s/VTXN+edBeBO3RXbHy4IiiovIgq/uJesdVK83F9roqV2SqIau5Jao2iaobppNpsH84sPJx+SBR+GpX31SMHVWohH2pwbh+/ED5rdCCRbzCRa4Gr6h9xDSKYPBa03hS2jzPFfhE0omb2s5IuujuRyRdnD1GeiYitkM0EXFdC/smcHd/QdLOTc0nJZ2f/X5e0sPNTgttILbDRFzXx6LvgR9y9zdnv78l6VC0o5mdNrMtM9va2bn5NYUemiu2H4zrv9qbHRa1QFz5e+27pT/EdHeX5BXbz7r7prtvbmxsLDscWlQV2w/G9RMtzwzLmD+u/L323aIJ/IqZ3SFJs59Xm5sSOkZsh4m4DtCia6E8K+lRSU/Mfj7T2IxWJAvao1uqRUeEu0sVC65UHtU39WMbFaGUtcXNkurfjiwvW6tDCgMbrSFStbZI3TukRecQ3f6tWnlf8fMUau5vdpKXt+dFfExna55kCxxTBK3lfRVBLKKnSZKKoJJnGh0zLm/e9wrczJ6U9AdJnzOzS2b2mHZfBA+Y2auSvjJ7jMQQ22Eirutj3ytwdz8VbPpyw3NBy4jtMBHX9cE3MQEgUSRwAEgUCRwAEtXqHXm2t7dLPz1v5e4ia2qBaoUGFaWtWVVlQEOvhfA1FQydj0ZVndXqK1R3f+3zXPXNZBRvG03K25v621/kdR6tlxP0NRqPanVf3stsjLxWVyGuwAEgUSRwAEgUCRwAEkUCB4BEkcABIFGtVqH0UdZoZ432lo4DB8rPPR+V7l5U3bklWqskqmgJnvOs7E4yVcq7390UbItGiOYaNletwzLKw229k1Vsm47K28fT8vZJUW/sKN7RHZgqTIO+ghEULccTtTeJK3AASBQJHAASRQIHgESRwAEgUSRwAEgUCRwAEtWLMsLwFlQtLHJVPnJ6ul20qlw4p8qFo4Lmybi8Pdg/koXDTut1tMDY06B8MgvKLXe35fUGSc04D9qD/YugPVosq0q4aFVe2j6uP8LKcQUOAIkigQNAokjgAJAoEjgAJIoEDgCJ2rcKxczOSXpQ0lV3v2/WNpb0LUlvz3b7rrs/1/TkFqmsGMLt2dqoKOkyrpWyoDmoxpiOxuUHRIsbLfKaqrs41bR8Qxbckqvydm4L6G1sm5AF7UW0f3SAwgW2Ko7onXmuwCeSTpS0/8jd75/9S++FgImI61BNRGzXwr4J3N1fkLTTwlzQIuI6XMR2fSzzHvjjZvZHMztnZp+MdjKz02a2ZWZbS4yF9tSO684OuSIR+8aWuKZl0QT+U0mflXS/pDcl/TDa0d3Puvumu28uOBbas1BcNzY2WpoeljBXbIlrWhZK4O5+xd3fc/f/SfqZpOPNTgtdIK7DRWyHydx9/53MMkm/3vOJ9h3u/ubs9+9I+oK7PzJHP29L+vvs4UFJ1xacd8r6cN53u/vtxLVRfTnvxmJLXCX157zvdvfbb27cN4Gb2ZOScu2eyBVJ3589vl+Sa7eA59vvvzjmZWZb6/i2Sl/Om7g2q0/nvYrY9un82tT38963DtzdT5U0/2IFc0GLiOtwEdv1wTcxASBRXSbwsx2O3aWhn/fQzy8y9PMe+vlFen3ec32ICQDoH95CAYBEkcABIFGdJHAzO2FmL5vZa2Z2pos5rNrs68pXzexPe9o2zOx5M3t19jP8qnqK1iGu0vrFlrj2N66tJ3Azu1XSTyR9TdK9kk6Z2b1tz6MFE314Rbgzki66+xFJF2ePB2GN4iqtUWyJa7/j2sUV+HFJr7n76+5+Q9JTkk52MI+VClaEOynp/Oz385IebnNOK7YWcZXWLrbEtcdx7SKB3ynpjT2PL83a1sGhPd9+e0vSoS4n07B1jqs03NgS1x7HlQ8xO+K79ZvUcA4QsR2mPsa1iwR+WdJdex4fnrWtgytmdoe0u7iQpKsdz6dJ6xxXabixJa49jmsXCfxFSUfM7B4zu03SI5Ke7WAeXXhW0qOz3x+V9EyHc2naOsdVGm5siWuf4+rurf+T9HVJr0j6m6TvdTGHFs7xSe0unP9f7b5v+JikT2n3k+xXJf1e0kbX8ySuxJa4phtXvkoPAIniQ0wASBQJHAASRQIHgESRwAEgUSRwAEgUCRwAEkUCB4BE/R+J4k1+/8zf3AAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 3 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# show quantized images (in which the values have been squished into a smaller range)\n",
+    "for i in range(len(images)):\n",
+    "    plt.subplot(1, len(images), i+1)\n",
+    "    pix = load_pixels(filenames[i])\n",
+    "    quantized_pix = pix//32 \n",
+    "    quantized_image = quantized_pix*32\n",
+    "    reshaped = quantized_image.reshape([16, 16, 3])\n",
+    "    plt.imshow(reshaped)\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 76,
+   "id": "496d1e08",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[  0   0   0]\n",
+      " [  0   0   0]\n",
+      " [  0   0   0]\n",
+      " [  0   0   0]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [  0   0   0]\n",
+      " [  0   0   0]\n",
+      " [  0   0   0]\n",
+      " [  0   0   0]\n",
+      " [  0   0   0]\n",
+      " [  0   0   0]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [  0   0   0]\n",
+      " [  0   0   0]\n",
+      " [  0   0   0]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [384  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [  0   0   0]\n",
+      " [  0   0   0]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  48   6]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [320  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [  0   0   0]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  48   6]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [320  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [384  56   7]\n",
+      " [320  48   7]\n",
+      " [384  48   7]\n",
+      " [448  48   6]\n",
+      " [448  48   6]\n",
+      " [448  48   6]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [320  56   7]\n",
+      " [384  56   7]\n",
+      " [448  56   7]\n",
+      " [448  48   6]\n",
+      " [320  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  48   6]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [320  56   7]\n",
+      " [448  56   7]\n",
+      " [448  48   7]\n",
+      " [448  56   7]\n",
+      " [384  56   7]\n",
+      " [384  56   7]\n",
+      " [448  56   7]\n",
+      " [448  48   6]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [320  56   7]\n",
+      " [448  56   7]\n",
+      " [384  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  48   6]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [320  56   7]\n",
+      " [384  56   7]\n",
+      " [448  56   7]\n",
+      " [320  56   7]\n",
+      " [448  48   6]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  48   6]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [384  56   7]\n",
+      " [320  48   7]\n",
+      " [448  48   6]\n",
+      " [384  48   7]\n",
+      " [448  48   6]\n",
+      " [448  48   6]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [320  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  48   6]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [  0   0   0]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [320  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  48   6]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [  0   0   0]\n",
+      " [  0   0   0]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [384  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [  0   0   0]\n",
+      " [  0   0   0]\n",
+      " [  0   0   0]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [  0   0   0]\n",
+      " [  0   0   0]\n",
+      " [  0   0   0]\n",
+      " [  0   0   0]\n",
+      " [  0   0   0]\n",
+      " [  0   0   0]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [448  56   7]\n",
+      " [  0   0   0]\n",
+      " [  0   0   0]\n",
+      " [  0   0   0]\n",
+      " [  0   0   0]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "pix = load_pixels(filenames[0])\n",
+    "\n",
+    "\n",
+    "# divide each pixel by 32 and round\n",
+    "quantized_pix = pix//32 \n",
+    "# print(quantized_pix)\n",
+    "\n",
+    "\n",
+    "# convert octal numbers to decimal numbers\n",
+    "# red is multiplied by 64\n",
+    "# green is multiplied by 8\n",
+    "# blue is multiplied by 1\n",
+    "multiplier = np.array([8**2, 8**1, 8**0])\n",
+    "\n",
+    "multiplied = quantized_pix*multiplier\n",
+    "print(multiplied)\n",
+    "\n",
+    "summed = np.sum(multiplied, axis=1)\n",
+    "\n",
+    "# print(summed)\n",
+    "\n",
+    "# pix[0],index[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 77,
+   "id": "30620097",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "203"
+       "array([0, 0, 0])"
       ]
      },
-     "execution_count": 50,
+     "execution_count": 77,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "pixels_with_this_color = histograms[indices[0]][511]"
+    "quantized_pix[0]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 78,
+   "id": "51c2ca8a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "184\n",
+      "100\n",
+      "132\n"
+     ]
+    }
+   ],
+   "source": [
+    "# print count of pixels with the \"511\" color\n",
+    "for i in range(len(images)):\n",
+    "    print(histograms[false_default_indices[i]][511])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 79,
    "id": "6356c9c2",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "0.96"
+       "0.97"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 79,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -706,7 +1035,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 80,
    "id": "40f00ac1",
    "metadata": {},
    "outputs": [
@@ -716,7 +1045,7 @@
        "0"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 80,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -730,7 +1059,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 81,
    "id": "59e901a2",
    "metadata": {},
    "outputs": [
@@ -740,7 +1069,7 @@
        "1"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 81,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
In today's pairing session @andreasjansson and I investigated why we were seeing false positives.

It turned out that we were over-quantizing our images from 256 colors to 8, and the light grey color of GitHub's default avatars was ending up with the same value as "white". This caused some custom avatars with white backgrounds to be detected as custom avatars.

<img width="910" alt="Screen Shot 2022-02-02 at 12 44 46 PM" src="https://user-images.githubusercontent.com/2289/152234447-f5af43c7-5976-4452-b1f4-44f9bf46225a.png">

